### PR TITLE
Fix typos/capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-**[Get it on WordPress.org](https://wordpress.org/plugins/fluent-smtp/) | [FaceBook Community](https://www.facebook.com/groups/fluentcrm) | [Docs](https://fluentsmtp.com/docs)**
+**[Get it on WordPress.org](https://wordpress.org/plugins/fluent-smtp/) | [Facebook Community](https://www.facebook.com/groups/fluentcrm) | [Docs](https://fluentsmtp.com/docs)**
 
 ![FluentSMTP Banner](https://ps.w.org/fluent-smtp/assets/banner-1544x500.png)
 
@@ -22,7 +22,7 @@ Connect as many Email Service Providers as you want and FluentCRM will route you
 - SendInBlue
 - PepiPost
 - SparkPost
-- gmail via SMTP
+- Gmail via SMTP
 - Zoho via SMTP
 - Outlook via SMTP
 - All Other SMTP
@@ -49,7 +49,7 @@ Please check `app/Http/routes.php` to see all the endpoints.
 
 All the email connect drivers are at: `app/Services/Mailer/Providers`
 
-#### Build Javascript source
+#### Build JavaScript source
 
 - Clone this project
 - open the project in terminal

--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,7 @@ Connect as many Email Service Providers as you want and FluentSMTP will route yo
 * SendInBlue
 * PepiPost
 * SparkPost
-* gmail via SMTP
+* Gmail via SMTP
 * Zoho via SMTP
 * Outlook via SMTP
 * All Other SMTP
@@ -139,8 +139,8 @@ Fluent SMTP is built by <a href="https://wpmanageninja.com">WPManageNinja LLC</a
 
 Fluent SMTP is a 100% free and opensource plugin and we will never release a pro version. It does not mean, It will have lack features. Our aim is to provide the ultimate SMTP/Email Service connection plugin for your WordPress Mails. We wrote <a href="https://fluentsmtp.com/why-we-build-fluentsmtp-plugin/">an article about why we made this plugin</a> and our plan about Fluent SMTP.
 
-The full source code is hosted in Github and you are welcomed to contribute to the development of this awesome WP Mail Plugin.
-👉 <a href="https://github.com/WPManageNinja/fluent-smtp">View on Github</a> 👈
+The full source code is hosted in GitHub and you are welcomed to contribute to the development of this awesome WP Mail Plugin.
+👉 <a href="https://github.com/WPManageNinja/fluent-smtp">View on GitHub</a> 👈
 
 == What's Next ==
 If you like this plugin, then consider checking out our other plugins:

--- a/resources/admin/Modules/Misc/Support.vue
+++ b/resources/admin/Modules/Misc/Support.vue
@@ -21,8 +21,8 @@
                                 <li>WordPress API</li>
                             </ul>
                             <p>
-                                If you find an issue or have a suggestion please <a target="_blank" rel="nofollow" href="https://github.com/WPManageNinja/fluent-smtp/issues">open an issue on Github</a>.
-                                <br/>If you are a developer and would like to contribute to the project, Please <a target="_blank" rel="nofollow" href="https://github.com/WPManageNinja/fluent-smtp/">contribute on Github</a>.
+                                If you find an issue or have a suggestion please <a target="_blank" rel="nofollow" href="https://github.com/WPManageNinja/fluent-smtp/issues">open an issue on GitHub</a>.
+                                <br/>If you are a developer and would like to contribute to the project, Please <a target="_blank" rel="nofollow" href="https://github.com/WPManageNinja/fluent-smtp/">contribute on GitHub</a>.
                             </p>
                             <p>Please <a target="_blank" rel="noopener" href="http://fluentsmtp.com/docs">read the documentation here</a></p>
                         </div>


### PR DESCRIPTION
Just a few minor typo/capitalization fixes, e.g. `Github` -> `GitHub`
