### PR TITLE
Respect provided filters and functionality of the original wp_mail() function

### DIFF
--- a/app/Functions/pluggable.php
+++ b/app/Functions/pluggable.php
@@ -40,6 +40,33 @@ if (! function_exists( 'wp_mail' ) ) :
         $atts = apply_filters(
             'wp_mail', compact('to', 'subject', 'message', 'headers', 'attachments')
         );
+        
+        /**
+		 * Filters whether to preempt sending an email.
+		 *
+		 * Returning a non-null value will short-circuit {@see wp_mail()}, returning
+		 * that value instead. A boolean return value should be used to indicate whether
+		 * the email was successfully sent.
+		 *
+		 * @since 5.7.0
+		 *
+		 * @param null|bool $return Short-circuit return value.
+		 * @param array     $atts {
+		 *     Array of the `wp_mail()` arguments.
+		 *
+		 *     @type string|string[] $to          Array or comma-separated list of email addresses to send message.
+		 *     @type string          $subject     Email subject.
+		 *     @type string          $message     Message contents.
+		 *     @type string|string[] $headers     Additional headers.
+		 *     @type string|string[] $attachments Paths to files to attach.
+		 * }
+		 */
+		$pre_wp_mail = apply_filters( 'pre_wp_mail', null, $atts );
+
+		if ( null !== $pre_wp_mail ) {
+			return $pre_wp_mail;
+		}
+        
 
         if ( isset( $atts['to'] ) ) {
             $to = $atts['to'];


### PR DESCRIPTION
The pluggable function is missing a very important WordPress filter `pre_wp_mail`.

This filter is often the only way to short-circuit the sending of emails that you dont want to got out. 
A good example of this might be a plugin thats does not offer dedicated hooks to control inbuilt email functionality. 

`pre_wp_mail` is often the last resort here to regain some control and customize some behaviour. 
I cant see any upside in removing this filter from the the pluggable function so please consider adding it back in. 

This PR is an exact replica of how the filter works inside the default `wp_mail()` function provided by WordPress