### PR TITLE
Disable recommended plugin installation when DISALLOW_FILE_MODS is defined

### DIFF
--- a/app/Hooks/Handlers/AdminMenuHandler.php
+++ b/app/Hooks/Handlers/AdminMenuHandler.php
@@ -114,6 +114,8 @@ class AdminMenuHandler
 
         $user = get_user_by('ID', get_current_user_id());
 
+        $disable_recommendation = defined('DISALLOW_FILE_MODS') && DISALLOW_FILE_MODS;
+
         wp_localize_script('fluent_mail_admin_app_boot', 'FluentMailAdmin', [
             'slug'                   => FLUENTMAIL,
             'brand_logo'             => esc_url(fluentMailMix('images/logo.svg')),
@@ -124,7 +126,7 @@ class AdminMenuHandler
             'user_email'             => $user->user_email,
             'require_optin'          => $this->isRequireOptin(),
             'has_ninja_tables'       => defined('NINJA_TABLES_VERSION'),
-            'disable_recommendation' => apply_filters('fluentmail_disable_recommendation', false),
+            'disable_recommendation' => $disable_recommendation ? true : apply_filters('fluentmail_disable_recommendation', false),
             'plugin_url'             => 'https://fluentsmtp.com/?utm_source=wp&utm_medium=install&utm_campaign=dashboard'
         ]);
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -109,7 +109,7 @@ class SettingsController extends Controller
         $this->verify();
 
         $settings = $settings->delete($request->get('key'));
-        
+
         return $this->sendSuccess($settings);
     }
 
@@ -142,7 +142,7 @@ class SettingsController extends Controller
                     'email_error' => __('The email field is required.', 'fluent-smtp')
                 ], 422);
             }
-            
+
             if (!defined('FLUENTMAIL_EMAIL_TESTING')) {
                 define('FLUENTMAIL_EMAIL_TESTING', true);
             }
@@ -236,7 +236,7 @@ class SettingsController extends Controller
             ]
         ];
 
-        if(!isset($UrlMaps[$pluginSlug])) {
+        if(!isset($UrlMaps[$pluginSlug]) || (defined('DISALLOW_FILE_MODS') && DISALLOW_FILE_MODS)) {
             $this->sendError([
                 'message' => __('Sorry, You can not install this plugin', 'fluent-smtp')
             ]);


### PR DESCRIPTION
As discussed in issue #44, this pull request will hide and block the installation of plugins from the support page when DISALLOW_FILE_MODS is defined and not set to false.