### PR TITLE
Remove capitalization on Connection Details

### DIFF
--- a/app/views/admin/general_connection_info.php
+++ b/app/views/admin/general_connection_info.php
@@ -2,19 +2,19 @@
     <table class="wp-list-table widefat striped">
         <tr>
             <th>Connection Type</th>
-            <td><?php echo ucfirst($connection['provider']); ?></td>
+            <td><?php echo $connection['provider']; ?></td>
         </tr>
         <tr>
             <th>Sender Email</th>
-            <td><?php echo ucfirst($connection['sender_email']); ?></td>
+            <td><?php echo $connection['sender_email']; ?></td>
         </tr>
         <tr>
             <th>Sender Name</th>
-            <td><?php echo ucfirst($connection['sender_name']); ?></td>
+            <td><?php echo $connection['sender_name']; ?></td>
         </tr>
         <tr>
             <th>Force Sender Name</th>
-            <td><?php echo ucfirst($connection['force_from_name']); ?></td>
+            <td><?php echo $connection['force_from_name']; ?></td>
         </tr>
         <?php if(isset($connection['extra_rows'])) : ?>
         <?php foreach ($connection['extra_rows'] as $row): ?>

--- a/app/views/admin/general_connection_info.php
+++ b/app/views/admin/general_connection_info.php
@@ -14,7 +14,7 @@
         </tr>
         <tr>
             <th>Force Sender Name</th>
-            <td><?php echo $connection['force_from_name']; ?></td>
+            <td><?php echo ucfirst($connection['force_from_name']); ?></td>
         </tr>
         <?php if(isset($connection['extra_rows'])) : ?>
         <?php foreach ($connection['extra_rows'] as $row): ?>

--- a/app/views/admin/ses_connection_info.php
+++ b/app/views/admin/ses_connection_info.php
@@ -18,11 +18,11 @@
         </tr>
         <tr>
             <th>Sender Email</th>
-            <td><?php echo ucfirst($connection['sender_email']); ?></td>
+            <td><?php echo $connection['sender_email']; ?></td>
         </tr>
         <tr>
             <th>Sender Name</th>
-            <td><?php echo ucfirst($connection['sender_name']); ?></td>
+            <td><?php echo $connection['sender_name']; ?></td>
         </tr>
         <tr>
             <th>Force Sender Name</th>


### PR DESCRIPTION
My "Sender Email" and "Sender Name" were displaying with a capital when that's not how I entered them. So I removed the `ucfirst()` on them. It's just a display thing.

The same goes for the service name. At the moment all services choose to have their name capitalized but there could be one added with a stylized name in the future.

However, I tested my change and noticed "Mailgun" is now displayed as "mailgun". So either this component is not using the styled/display variable, or somewhere else in the plugin you should change "mailgun" to "Mailgun". This likely goes for all services.

Rock on!