### PR TITLE
I propose this fix for issue #7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,41 +1,42 @@
 {
-  "name": "fluent-smtp",
-  "version": "1.0.0",
-  "description": "---",
-  "main": ".eslintrc.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/WPManageNinja/fluent-smtp.git"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/WPManageNinja/fluent-smtp/issues"
-  },
-  "homepage": "https://github.com/WPManageNinja/fluent-smtp#readme",
-  "devDependencies": {
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-    "@wordpress/hooks": "^3.2.0",
-    "babel-plugin-import": "^1.13.3",
-    "laravel-mix": "^6.0.25",
-    "resolve-url-loader": "^4.0.0",
-    "sass": "^1.36.0",
-    "sass-loader": "^12.1.0",
-    "vue-loader": "^15.9.7",
-    "vue-template-compiler": "^2.6.14"
-  },
-  "dependencies": {
-    "chart.js": "^3.4.1",
-    "css-loader": "^5.2.7",
-    "dayjs": "^1.10.6",
-    "element-ui": "^2.15.3",
-    "lodash": "^4.17.21",
-    "vue": "^2.6.14",
-    "vue-chartjs": "^3.5.1",
-    "vue-router": "^3.5.2"
-  }
+    "name": "fluent-smtp",
+    "version": "1.0.0",
+    "description": "---",
+    "main": ".eslintrc.js",
+    "scripts": {
+        "start": "webpack --mode=development --node-env=dev --progress --watch",
+        "prod": "webpack --mode=production --node-env=prod --progress"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/WPManageNinja/fluent-smtp.git"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/WPManageNinja/fluent-smtp/issues"
+    },
+    "homepage": "https://github.com/WPManageNinja/fluent-smtp#readme",
+    "devDependencies": {
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@wordpress/hooks": "^3.2.0",
+        "babel-plugin-import": "^1.13.3",
+        "laravel-mix": "^6.0.25",
+        "resolve-url-loader": "^4.0.0",
+        "sass": "^1.36.0",
+        "sass-loader": "^12.1.0",
+        "vue-loader": "^15.9.7",
+        "vue-template-compiler": "^2.6.14"
+    },
+    "dependencies": {
+        "chart.js": "^3.4.1",
+        "css-loader": "^5.2.7",
+        "dayjs": "^1.10.6",
+        "element-ui": "^2.15.3",
+        "lodash": "^4.17.21",
+        "vue": "^2.6.14",
+        "vue-chartjs": "^3.5.1",
+        "vue-router": "^3.5.2"
+    }
 }

--- a/resources/admin/Bits/FluentMail.js
+++ b/resources/admin/Bits/FluentMail.js
@@ -82,6 +82,8 @@ locale.use(lang);
 
 import Router from 'vue-router';
 import dayjs from 'dayjs';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+
 import {
     applyFilters,
     addFilter,
@@ -100,6 +102,7 @@ export default class FluentMail {
         this.removeAllActions = removeAllActions;
         this.appVars = window.FluentMailAdmin;
         this.Vue = this.extendVueConstructor();
+        // dayjs.extend(localizedFormat);
     }
 
     extendVueConstructor() {
@@ -122,7 +125,7 @@ export default class FluentMail {
                 ucFirst: self.ucFirst,
                 ucWords: self.ucWords,
                 slugify: self.slugify,
-                dayjs: dayjs,
+                dayjs: dayjs.extend(localizedFormat),
                 escapeHtml: self.escapeHtml,
                 hasPro: () => Boolean(window.FluentMail.appVars.has_pro),
                 $t(string) {

--- a/resources/admin/Modules/Logger/Logs.vue
+++ b/resources/admin/Modules/Logger/Logs.vue
@@ -3,7 +3,7 @@
         <div>
             <div class="header">
                 <div style="float:left;margin-top:6px;">{{$t('Email Logs')}}</div>
-                
+
                 <LogFilter
                     @on-filter="onFilter"
                     @on-filter-change="onFilterChange"
@@ -47,13 +47,13 @@
                             <div>{{ scope.row.subject }}</div>
                         </template>
                     </el-table-column>
-                    
+
                     <el-table-column :label="$t('To')">
                         <template slot-scope="scope">
                             <span v-html="scope.row.to"></span>
                         </template>
                     </el-table-column>
-                    
+
                     <el-table-column :label="$t('Status')" width="120" align="center">
                         <template slot-scope="scope">
                             {{ scope.row.status }}
@@ -322,7 +322,7 @@
                     const logViewer = this.$children.find(
                         c => c.$options._componentTag === 'LogViewer'
                     );
-                    
+
                     logViewer && logViewer.navigate();
                 });
             },
@@ -432,7 +432,7 @@
                 return this.logs.map(log => {
                     log.created_at = this.$dateFormat(
                         log.created_at,
-                        'DD-MM-YYYY h:mm:ss A'
+                        'L LT'
                     );
                     return log;
                 });
@@ -446,7 +446,7 @@
         },
         created() {
             const currentPage = this.$route.query.page;
-            
+
             if (currentPage) {
                 this.pagination.current_page = Number(currentPage);
             }


### PR DESCRIPTION
fixes #7 where "Date-Time" column in "Email Logs" would not format for the user's locale.

This update uses dayjs's `dayjs.extend(localizedFormat)` function to allow dates to automatically format for the user's locale.  This mostly just replaces the hard-coded date time format with a format that is locale-aware.

Note: the package.json file now includes build scripts for anyone who doesn't use npx.  `npm start` to build and watch with webpack 5, `npm run prod` to build in production mode (webpack 5)