### PR TITLE
Added target="_blank" in the documentation links

### DIFF
--- a/app/Services/Mailer/Providers/config.php
+++ b/app/Services/Mailer/Providers/config.php
@@ -26,7 +26,7 @@ return [
                 'encryption'       => 'none',
                 'key_store'        => 'db'
             ],
-            'note'     => '<a href="https://fluentsmtp.com/docs/set-up-fluent-smtp-with-any-host-or-mailer/">Read the documentation</a> for how to configure any SMTP with FluentSMTP.'
+            'note'     => '<a href="https://fluentsmtp.com/docs/set-up-fluent-smtp-with-any-host-or-mailer/" target="_blank" rel="noopener">Read the documentation</a> for how to configure any SMTP with FluentSMTP.'
         ],
         'ses'         => [
             'key'      => 'ses',
@@ -67,7 +67,7 @@ return [
                 'af-south-1'     => __('Africa (Cape Town)', 'fluent-smtp'),
                 'cn-northwest-1' => __('China (Ningxia)', 'fluent-smtp')
             ],
-            'note'     => '<a href="https://fluentsmtp.com/docs/set-up-amazon-ses-in-fluent-smtp/">Read the documentation</a> for how to configure Amazon SES with FluentSMTP.'
+            'note'     => '<a href="https://fluentsmtp.com/docs/set-up-amazon-ses-in-fluent-smtp/" target="_blank" rel="noopener">Read the documentation</a> for how to configure Amazon SES with FluentSMTP.'
         ],
         'mailgun'     => [
             'key'      => 'mailgun',
@@ -84,7 +84,7 @@ return [
                 'key_store'       => 'db',
                 'region'          => 'us'
             ],
-            'note'     => '<a href="https://fluentsmtp.com/docs/configure-mailgun-in-fluent-smtp-to-send-emails/">Read the documentation</a> for how to configure Mailgun with FluentSMTP.'
+            'note'     => '<a href="https://fluentsmtp.com/docs/configure-mailgun-in-fluent-smtp-to-send-emails/" target="_blank" rel="noopener">Read the documentation</a> for how to configure Mailgun with FluentSMTP.'
         ],
         'sendgrid'    => [
             'key'      => 'sendgrid',
@@ -98,7 +98,7 @@ return [
                 'api_key'         => '',
                 'key_store'       => 'db'
             ],
-            'note'     => '<a href="https://fluentsmtp.com/docs/set-up-the-sendgrid-driver-in-fluent-smtp/">Read the documentation</a> for how to configure sendgrid with FluentSMTP.'
+            'note'     => '<a href="https://fluentsmtp.com/docs/set-up-the-sendgrid-driver-in-fluent-smtp/" target="_blank" rel="noopener">Read the documentation</a> for how to configure sendgrid with FluentSMTP.'
         ],
         'sendinblue'  => [
             'key'      => 'sendinblue',
@@ -112,7 +112,7 @@ return [
                 'api_key'         => '',
                 'key_store'       => 'db'
             ],
-            'note'     => '<a href="https://fluentsmtp.com/docs/setting-up-sendinblue-mailer-in-fluent-smtp/">Read the documentation</a> for how to configure Sendinblue with FluentSMTP.'
+            'note'     => '<a href="https://fluentsmtp.com/docs/setting-up-sendinblue-mailer-in-fluent-smtp/" target="_blank" rel="noopener">Read the documentation</a> for how to configure Sendinblue with FluentSMTP.'
         ],
         'sparkpost'   => [
             'key'      => 'sparkpost',
@@ -126,7 +126,7 @@ return [
                 'api_key'         => '',
                 'key_store'       => 'db'
             ],
-            'note'     => '<a href="https://fluentsmtp.com/docs/configure-sparkpost-in-fluent-smtp-to-send-emails/">Read the documentation</a> for how to configure SparkPost with FluentSMTP.'
+            'note'     => '<a href="https://fluentsmtp.com/docs/configure-sparkpost-in-fluent-smtp-to-send-emails/" target="_blank" rel="noopener">Read the documentation</a> for how to configure SparkPost with FluentSMTP.'
         ],
         'pepipost'    => [
             'key'      => 'pepipost',
@@ -140,7 +140,7 @@ return [
                 'api_key'         => '',
                 'key_store'       => 'db'
             ],
-            'note'     => '<a href="https://fluentsmtp.com/docs/set-up-the-pepipost-mailer-in-fluent-smtp/">Read the documentation</a> for how to configure Pepipost with FluentSMTP.'
+            'note'     => '<a href="https://fluentsmtp.com/docs/set-up-the-pepipost-mailer-in-fluent-smtp/" target="_blank" rel="noopener">Read the documentation</a> for how to configure Pepipost with FluentSMTP.'
         ],
         'postmark'    => [
             'key'      => 'postmark',
@@ -157,7 +157,7 @@ return [
                 'message_stream'  => 'outbound',
                 'key_store'       => 'db'
             ],
-            'note'     => '<a href="https://fluentsmtp.com/docs/configure-postmark-in-fluent-smtp-to-send-emails/">Read the documentation</a> for how to configure Postmark with FluentSMTP.'
+            'note'     => '<a href="https://fluentsmtp.com/docs/configure-postmark-in-fluent-smtp-to-send-emails/" target="_blank" rel="noopener">Read the documentation</a> for how to configure Postmark with FluentSMTP.'
         ],
 //        'elasticmail' => [
 //            'key'      => 'elasticmail',

--- a/resources/admin/Modules/Misc/Docs.vue
+++ b/resources/admin/Modules/Misc/Docs.vue
@@ -2,8 +2,8 @@
     <div class="fc_docs">
         <div style="max-width: 800px; margin: 50px auto; padding: 0px 20px; text-align: center;" class="fc_doc_header text-align-center">
             <h1>How can we help you?</h1>
-            <p>Please view the <a href="https://fluentsmtp.com/docs">documentation</a> first. If you still can't find the
-                answer <a href="https://wpmanageninja.com/support-tickets/">open a support ticket</a> and we will be
+            <p>Please view the <a href="https://fluentsmtp.com/docs" target="_blank" rel="noopener">documentation</a> first. If you still can't find the
+                answer <a href="https://wpmanageninja.com/support-tickets/" target="_blank" rel="noopener">open a support ticket</a> and we will be
                 happy to answer your questions and assist you with any problems.</p>
             <el-input
                 v-loading="fetching"


### PR DESCRIPTION
Some of the documentation links doesn't have the target="blank" attribute. 