### PR TITLE
Mailgun: fix sending plain text emails

### DIFF
--- a/app/Services/Mailer/Providers/Mailgun/Handler.php
+++ b/app/Services/Mailer/Providers/Mailgun/Handler.php
@@ -38,13 +38,18 @@ class Handler extends BaseHandler
 
     public function postSend()
     {
+        $content_type = $this->getHeader('content-type');
         $body = [
             'from'           => $this->getFrom(),
             'subject'        => $this->getSubject(),
-            'html'           => $this->getBody(),
             'h:X-Mailer'     => 'FluentMail - Mailgun',
-            'h:Content-Type' => $this->getHeader('content-type')
+            'h:Content-Type' => $content_type
         ];
+        if (stripos($content_type, 'html') === false) {
+            $body['text'] = $this->getBody();
+        } else {
+            $body['html'] = $this->getBody();
+        }
 
         if ($replyTo = $this->getReplyTo()) {
             $body['h:Reply-To'] = $replyTo;


### PR DESCRIPTION
Mailgun handler assumed HTML emails.   It should inspect the content type and set text or html body param appropriately.