### PR TITLE
Add number arg to the get_sites() call.

### DIFF
--- a/database/FluentMailDBMigrator.php
+++ b/database/FluentMailDBMigrator.php
@@ -11,7 +11,7 @@ class FluentMailDBMigrator
 
         if ($network_wide ) {
             if (function_exists('get_sites') && function_exists('get_current_network_id')) {
-                $site_ids = get_sites(['fields' => 'ids', 'network_id' => get_current_network_id()]);
+                $site_ids = get_sites(['fields' => 'ids', 'network_id' => get_current_network_id(), 'number' => get_blog_count()]);
             } else {
                 $site_ids = $wpdb->get_col(
                     "SELECT blog_id FROM $wpdb->blogs WHERE site_id = $wpdb->siteid;"


### PR DESCRIPTION
The `get_sites()` function returns only 100 sites by default.  
https://developer.wordpress.org/reference/classes/wp_site_query/__construct/#parameters  
> 'number'
> (int) Maximum number of sites to retrieve. Default 100.

If a multisite has over 100 sites the activation hook will not create the database tables needed for email logging for any site over the first 100 returned.

This change adds the `number` key to the `$args` array passed into the `get_sites()` call, with the value being set to the blog count returned from `get_blog_count()`. 

Side note, `get_blog_count()` shouldn't need the current network ID passed into it because it defaults to the current network and that is also what the `get_sites()` call is doing.