### PR TITLE
Add log tables on new site creation.

### DIFF
--- a/app/Hooks/Handlers/InitializeSiteHandler.php
+++ b/app/Hooks/Handlers/InitializeSiteHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FluentMail\App\Hooks\Handlers;
+
+class InitializeSiteHandler
+{
+    public function addHandler()
+    {
+        add_action('wp_initialize_site', array($this, 'handle'));
+    }
+
+    public static function handle( $new_site )
+    {
+        require_once(FLUENTMAIL_PLUGIN_PATH . 'database/migrations/EmailLogs.php');
+        
+        $blog_id = $new_site->blog_id;
+        switch_to_blog((int)$blog_id);
+        \FluentMailMigrations\EmailLogs::migrate();
+        restore_current_blog();
+    }
+}

--- a/app/Hooks/actions.php
+++ b/app/Hooks/actions.php
@@ -4,6 +4,8 @@
 
 (new \FluentMail\App\Hooks\Handlers\SchedulerHandler())->register();
 
+(new \FluentMail\App\Hooks\Handlers\InitializeSiteHandler())->addHandler();
+
 $app->addCustomAction('handle_exception', 'ExceptionHandler@handle');
 
 $app->addAction('admin_notices', 'AdminMenuHandler@maybeAdminNotice');

--- a/database/FluentMailDBMigrator.php
+++ b/database/FluentMailDBMigrator.php
@@ -11,7 +11,7 @@ class FluentMailDBMigrator
 
         if ($network_wide ) {
             if (function_exists('get_sites') && function_exists('get_current_network_id')) {
-                $site_ids = get_sites(['fields' => 'ids', 'network_id' => get_current_network_id(), 'number' => get_blog_count()]);
+                $site_ids = get_sites(['fields' => 'ids', 'network_id' => get_current_network_id(), 'number' => 0]);
             } else {
                 $site_ids = $wpdb->get_col(
                     "SELECT blog_id FROM $wpdb->blogs WHERE site_id = $wpdb->siteid;"


### PR DESCRIPTION
This MR adds code that creates the needed log tables on creation of a new site in a multisite network using the [`wp_initialize_site`](https://developer.wordpress.org/reference/hooks/wp_initialize_site/) hook.

I tried to add this code in the same code style as other parts of the plugin, but please make adjustments as needed to better match the design of the plugin.

I also updated the call to `get_blog_count()` that I had previously submitted as I did more digging and testing and learned that are are some inconsistencies with that function and `get_sites()`. I dug into `get_sites()` more and found that passing `0` as the `'number'` argument will return all sites regardless of a sites archived / deleted / public status (This fact is not documented by WordPress, and also doesn't follow their usual `-1` returns all pattern 😞 ).

With this change I was able to activate the plugin on a multisite of 1,400+  sites with no issues!