### PR TITLE
Ignore *.sublime-*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ assets
 !assets/index.php
 package-lock.json
 .DS_Store
+*.sublime-*


### PR DESCRIPTION
Sublime Text stores Project metadata in `name.sublime-project` and  `name.sublime-workspace` files. These should never be committed. So to keep them from permanently being in git's WIP / Unstaged Files category we should git-ignore them.