### PR TITLE
Update connections grid styles

### DIFF
--- a/resources/admin/Modules/Settings/Partials/_ConnectionSelector.vue
+++ b/resources/admin/Modules/Settings/Partials/_ConnectionSelector.vue
@@ -10,7 +10,7 @@
         </div>
         <el-radio-group @change="showAll = false" v-else class="fss_connections" v-model="connection.provider">
             <el-radio-button :class="'con_'+providerName" v-for="(provider, providerName) in providers" :key="providerName" :label="providerName">
-                <img @click="showAll = false" :title="provider.title" style="max-width:80px;height:32px;" :src="provider.image" />
+                <img @click="showAll = false" :title="provider.title" :src="provider.image" />
             </el-radio-button>
         </el-radio-group>
     </div>

--- a/resources/scss/fluent-mail-admin.scss
+++ b/resources/scss/fluent-mail-admin.scss
@@ -328,17 +328,24 @@ span.header_action_right {
 }
 
 .fss_connection_wizard {
-  .con_gmail .el-radio-button__inner img {
-    max-width: 186px !important;
+  .fss_connections {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    .el-radio-button__inner {
+      padding: 10px;
+    }
+    img {
+      width: 100px;
+      height: 60px;
+      object-fit: contain;
+    }
   }
 
   .con_gmail.is-active .el-radio-button__inner {
     background: #eff4f7 !important;
     border-color: #ea4435;
     box-shadow: -1px 0 0 0 #ea4435;
-  }
-  .fss_connections .el-radio-button__inner {
-    padding: 12px 6px;
   }
 
   .con_outlook.is-active .el-radio-button__inner {

--- a/resources/scss/vendor.scss
+++ b/resources/scss/vendor.scss
@@ -156,10 +156,6 @@ ul.fc_list {
   }
 }
 
-.con_elasticmail span {
-  padding: 12px 25px !important;
-}
-
 .fsmtp_conncection_selected {
   display: inline-block;
   padding: 15px 30px 5px 10px;
@@ -184,7 +180,3 @@ ul.fc_list {
     }
   }
 }
-.fss_connections > label {
-  margin-bottom: 10px;
-}
-


### PR DESCRIPTION
The current connection grid has a few problems that I wanted to fix:
- some logos take up more space
- tall logos get stretched out of proportion
- with multiple rows, we get spacing between rows, but not between items / columns

Current:
![fluent-smtp-grid-old](https://user-images.githubusercontent.com/2203813/188200201-80e65c91-f18f-40e5-a8e2-8bc38b578a6a.png)

New:
![fluent-smtp-grid-new](https://user-images.githubusercontent.com/2203813/188200187-cf776f88-eb63-4f0f-99fb-a5e709df5909.png)