### PR TITLE
Update SchedulerHandler.php

### DIFF
--- a/app/Hooks/Handlers/SchedulerHandler.php
+++ b/app/Hooks/Handlers/SchedulerHandler.php
@@ -53,7 +53,7 @@ class SchedulerHandler
         }
 
         $sendTo = $settings['notify_email'];
-        $sendTo = str_replace('{admin_email}', get_option('admin_email'), $sendTo);
+        $sendTo = str_replace('{site_admin}', get_option('admin_email'), $sendTo);
 
         $sendToArray = explode(',', $sendTo);
 


### PR DESCRIPTION
The summary notification email field defaults to {site_admin}, but line 56 is looking for the placeholder {admin_email} and replaces that with the actual admin email address. These two strings don’t match so the default placeholder will never work.

I've edited line 56 to look for the placeholder, {site_admin}

First reported here: https://wordpress.org/support/topic/not-receiving-summary-notifications/