### PR TITLE
Update SchedulerHandler.php

### DIFF
--- a/app/Hooks/Handlers/SchedulerHandler.php
+++ b/app/Hooks/Handlers/SchedulerHandler.php
@@ -121,11 +121,11 @@ class SchedulerHandler
 
         $sentTitle = __('Emails Sent', 'fluent-smtp');
         if($sentCount) {
-            $sentTitle .= ' <span style="font-size: 12px; vertical-align: middle;">('.number_format_i18n($sentCount).')</span>';
+            $sentTitle .= '('.number_format_i18n($sentCount).')';
         }
         $failedTitle = __('Email Failures', 'fluent-smtp');
         if($failedCount) {
-            $failedTitle .= ' <span style="font-size: 12px; vertical-align: middle;">('.number_format_i18n($failedCount).')</span>';
+            $failedTitle .= '('.number_format_i18n($failedCount).')';
         }
 
         $reportingDate = date(get_option('date_format'), strtotime($startDate));


### PR DESCRIPTION
Removed span tags - they do not work with Gmail. The html code shows inline.

<img width="649" alt="Screen Shot 2022-09-12 at 10 08 09 AM" src="https://user-images.githubusercontent.com/1851688/189714614-f225b2c4-b348-41f4-8165-46f22d109d7f.png">

First reported here: https://wordpress.org/support/topic/not-receiving-summary-notifications/