### PR TITLE
allow disabling emails via wp-config.php

### DIFF
--- a/app/Functions/helpers.php
+++ b/app/Functions/helpers.php
@@ -100,7 +100,7 @@ if (!function_exists('fluentMailGetProvider')) {
 
         $misc = $manager->getSettings('misc');
 
-        if (!empty($misc['simulate_emails']) && $misc['simulate_emails'] == 'yes') {
+        if ((!empty($misc['simulate_emails']) && $misc['simulate_emails'] == 'yes') || (defined('FLUENTMAIL_SIMULATE_EMAILS') && FLUENTMAIL_SIMULATE_EMAILS)) {
             $providers[$fromEmail] = new FluentMail\App\Services\Mailer\Providers\Simulator\Handler();
             return $providers[$fromEmail];
         }

--- a/app/Hooks/Handlers/AdminMenuHandler.php
+++ b/app/Hooks/Handlers/AdminMenuHandler.php
@@ -237,7 +237,7 @@ class AdminMenuHandler
 
         $misc = $this->app->make(Manager::class)->getConfig('misc');
 
-        if (!empty($misc['simulate_emails']) && $misc['simulate_emails'] == 'yes') {
+        if ((!empty($misc['simulate_emails']) && $misc['simulate_emails'] == 'yes') || (defined('FLUENTMAIL_SIMULATE_EMAILS') && FLUENTMAIL_SIMULATE_EMAILS)) {
             $args = [
                 'parent' => 'top-secondary',
                 'id'     => 'fluentsmtp_simulated',


### PR DESCRIPTION
Add the FLUENTMAIL_SIMULATE_EMAILS constant to enforce simulation mode via wp-config.php. This especially helps with cases where a site is being cloned to a staging/development install and might start sending emails before the site owner can visit the wp-admin to enable simulation mode. For example, when email automations are configured in FluentCRM, one doesn't want a staging site sending out emails to customers.
The admin-bar notification is also triggered so that admins know that email sending is disabled.