### PR TITLE
Fixed deprecated null argument in PHP 8.1

### DIFF
--- a/includes/OAuth2Provider.php
+++ b/includes/OAuth2Provider.php
@@ -100,7 +100,7 @@ class OAuth2Provider
      */
     protected function buildQueryString(array $params)
     {
-        return http_build_query($params, null, '&', \PHP_QUERY_RFC3986);
+        return http_build_query($params, '', '&', \PHP_QUERY_RFC3986);
     }
 
     /**


### PR DESCRIPTION
The function `http_build_query()` does not accept a `null` value anymore for the `$numeric_prefix` argument. Replacing the `null` with an empty string resolves the problem.

```
PHP Deprecated:  http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated in /wp-content/plugins/fluent-smtp/includes/OAuth2Provider.php on line 103
```