### PR TITLE
Excluding password from sanitize_text_field()

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -61,6 +61,9 @@ class SettingsController extends Controller
             $connection = $data['connection'];
 
             foreach ($connection as $index => $value) {
+                if ($index == 'password') {
+                    $connection['password'] = trim($value);
+                }
                 if ($index == 'sender_email') {
                     $connection['sender_email'] = sanitize_email($connection['sender_email']);
                 }


### PR DESCRIPTION
Using a strong, generated password we couldn't get a test email to send. It resulted in authentication error. Looking at the stored password we saw that it was truncated at a '<' character. Found the field was being passed through sanitize_text_field in the settings controller. 

Causes the following issues:
* Any HTML entities in password end up encoded.
* A password with < will be truncated (strip_tags function)
* A password < and > will have them and any text in between removed (strip_tags function).

update_option() will handle SQL escapes in the settings model store function.