### PR TITLE
update API endpoint new domain of brevo formarly Sendinblue

### DIFF
--- a/app/Services/Mailer/Providers/SendInBlue/Handler.php
+++ b/app/Services/Mailer/Providers/SendInBlue/Handler.php
@@ -15,7 +15,7 @@ class Handler extends BaseHandler
     
     protected $emailSentCode = 201;
 
-    protected $url = 'https://api.sendinblue.com/v3/smtp/email';
+    protected $url = 'https://api.brevo.com/v3/smtp/email';
 
     protected $allowedAttachmentExts = [
         'xlsx', 'xls', 'ods', 'docx', 'docm', 'doc', 'csv', 'pdf', 'txt', 'gif',


### PR DESCRIPTION
Sendinblue now brevo, so they update their API endpoints, I believe you also need to update. Here is new API details https://developers.brevo.com/reference/sendtransacemail