### PR TITLE
Mailgun - enable custom headers (list-unsubscribe)

### DIFF
--- a/app/Services/Mailer/Providers/Mailgun/Handler.php
+++ b/app/Services/Mailer/Providers/Mailgun/Handler.php
@@ -65,6 +65,11 @@ class Handler extends BaseHandler
             $body = array_merge($body, $recipients);
         }
 
+        foreach ($this->getParam('custom_headers') as $header) {
+            $key = trim($header['key']);
+            $body['h:' . $key] = trim($header['value']);
+        }
+
         $params = [
             'body'    => $body,
             'headers' => $this->getRequestHeaders()


### PR DESCRIPTION
The Mailgun Service Handler does not currently check for or honor custom headers that have been set in phpmailer.  This caused the "list-unsubscribe" header from FluentCRM to be lost when sending via Mailgun.

Used and slightly modified code from Elastic Mail handler to keep coding consistent to enable this in the Mailgun Handler.