### PR TITLE
Add adapter and adapterConfig properties to QueryBuilderHandler

### DIFF
--- a/app/Services/DB/QueryBuilder/QueryBuilderHandler.php
+++ b/app/Services/DB/QueryBuilder/QueryBuilderHandler.php
@@ -47,6 +47,14 @@ class QueryBuilderHandler
      * @var array
      */
     protected $fetchParameters = array(\PDO::FETCH_OBJ);
+    /**
+     * @var string
+     */
+    private $adapter;
+    /**
+     * @var array
+     */
+    private $adapterConfig;
 
     /**
      * @param null|\FluentMail\App\Services\DB\Connection $connection


### PR DESCRIPTION
Two new private properties, adapter and adapterConfig, are added to the QueryBuilderHandler class. These properties were added to avoid deprecation notices in PHP 8.2 +