### PR TITLE
Fix SparkPost integration: correct recipient address handling and content headers format

### DIFF
--- a/app/Services/Mailer/Providers/SparkPost/Handler.php
+++ b/app/Services/Mailer/Providers/SparkPost/Handler.php
@@ -30,7 +30,7 @@ class Handler extends BaseHandler
     {
         $body = [
             'options' => [
-                'sandbox' => defined('FLUENTMAIL_TEST_EMAIL')
+                'sandbox' => false
             ],
             'content' => [
                 'from' => $this->getFrom(),
@@ -39,14 +39,7 @@ class Handler extends BaseHandler
                 'text' => $this->phpMailer->AltBody,
                 'headers' => []
             ],
-            'recipients' => [
-                [
-                    'address' => [
-                        'name' => $this->getParam('sender_name'),
-                        'email' => $this->getParam('sender_email')
-                    ]
-                ]
-            ],
+            'recipients' => $this->getTo(),
             'cc' => $this->getCarbonCopy(),
             'bcc' => $this->getBlindCarbonCopy()
         ];
@@ -112,6 +105,21 @@ class Handler extends BaseHandler
         }
 
         return $from;
+    }
+
+    protected function getTo()
+    {
+        $address = [];
+
+        foreach ($this->getParam('to') as $to) {
+            $address[] = [
+                'address' => [
+                    'email' => $to['email']
+                ]
+            ];
+        }
+
+        return $address;
     }
 
     protected function getReplyTo()

--- a/app/Services/Mailer/Providers/SparkPost/Handler.php
+++ b/app/Services/Mailer/Providers/SparkPost/Handler.php
@@ -37,7 +37,7 @@ class Handler extends BaseHandler
                 'subject' => $this->getSubject(),
                 'html' => $this->phpMailer->Body,
                 'text' => $this->phpMailer->AltBody,
-                'headers' => []
+                'headers' => (object) []
             ],
             'recipients' => $this->getTo(),
             'cc' => $this->getCarbonCopy(),


### PR DESCRIPTION
This commit addresses two key issues with the SparkPost integration in FluentSMTP:

1. **Correct Recipient Address Handling:**
   - Added a new `getTo()` method to properly set the `recipients` field in the SparkPost request body.
   - Previously, the recipient address was incorrectly set to the sender's address, causing emails to fail or be misdirected.
   - The `getTo()` method now retrieves the intended recipient addresses from the parameters, ensuring accurate delivery.

2. **Fix Content Headers Format:**
   - Adjusted `content.headers` to be structured as a JSON object instead of an array, aligning with SparkPost API requirements.
   - This change resolves #221 and #166 the `json_array` to `json_object` error that occurred when sending emails. 

3. **Adjust Sandbox Mode:**
   - Set `sandbox` to `false` in the `options` field to prevent SparkPost’s `550 5.7.1 Sending domain sandbox option mismatch` error.
   - SparkPost allows only up to 5 emails to be sent in sandbox mode per account, causing issues with test emails for FluentSMTP users.
   - For more details on SparkPost’s sandbox restrictions, see the documentation [here](https://developers.sparkpost.com/api/transmissions/#header-the-sandbox-domain).

