### PR TITLE
Improve localization

### DIFF
--- a/app/Hooks/Handlers/AdminMenuHandler.php
+++ b/app/Hooks/Handlers/AdminMenuHandler.php
@@ -92,7 +92,7 @@ class AdminMenuHandler
             // This widget should be displayed for certain high-level users only.
             if (!current_user_can('manage_options') || apply_filters('fluent_mail_disable_dashboard_widget', false)) {
                 wp_send_json([
-                    'html' => 'You do not have permission to see this data'
+                    'html' => _('You do not have permission to see this data', 'fluent-smtp')
                 ]);
             }
 
@@ -230,8 +230,8 @@ class AdminMenuHandler
         add_filter('admin_footer_text', function ($text) {
             return sprintf(
                 __('<b>FluentSMTP</b> is a free plugin & it will be always free %1$s. %2$s', 'fluent-smtp'),
-                '<a href="https://fluentsmtp.com/why-we-built-fluentsmtp-plugin/" target="_blank" rel="noopener noreferrer">(Learn why it\'s free)</a>',
-                '<a href="https://wordpress.org/support/plugin/fluent-smtp/reviews/?filter=5" target="_blank" rel="noopener noreferrer">Write a review ★★★★★</a>'
+                '<a href="https://fluentsmtp.com/why-we-built-fluentsmtp-plugin/" target="_blank" rel="noopener noreferrer"><?php esc_html_e('(Learn why it\'s free)', 'fluent-smtp'); ?></a>',
+                '<a href="https://wordpress.org/support/plugin/fluent-smtp/reviews/?filter=5" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Write a review ★★★★★', 'fluent-smtp'); ?></a>'
             );
         });
     }
@@ -364,7 +364,7 @@ class AdminMenuHandler
             }
         </style>
         <div id="fsmtp_dashboard_widget_html" class="fsmtp_dash_wrapper">
-            <h3 style="min-height: 170px;">Loading data....</h3>
+            <h3 style="min-height: 170px;"><?php esc_html_e('Loading data...', 'fluent-smtp'); ?></h3>
         </div>
         <?php
         add_action('admin_footer', function () {

--- a/app/Hooks/Handlers/AdminMenuHandler.php
+++ b/app/Hooks/Handlers/AdminMenuHandler.php
@@ -92,7 +92,7 @@ class AdminMenuHandler
             // This widget should be displayed for certain high-level users only.
             if (!current_user_can('manage_options') || apply_filters('fluent_mail_disable_dashboard_widget', false)) {
                 wp_send_json([
-                    'html' => _('You do not have permission to see this data', 'fluent-smtp')
+                    'html' => __('You do not have permission to see this data', 'fluent-smtp')
                 ]);
             }
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -470,7 +470,7 @@ class SettingsController extends Controller
 
         if (!is_email($email)) {
             return $this->sendError([
-                'message' => 'Sorry! The provider email is not valid'
+                'message' => __('Sorry! The provider email is not valid', 'fluent-smtp')
             ], 422);
         }
 
@@ -486,7 +486,7 @@ class SettingsController extends Controller
         $this->pushData($email, $shareEssentials, $displayName);
 
         return $this->sendSuccess([
-            'message' => 'You are subscribed to plugin update and monthly tips'
+            'message' => __('You are subscribed to plugin update and monthly tips', 'fluent-smtp')
         ]);
     }
 

--- a/app/Services/Mailer/Providers/config.php
+++ b/app/Services/Mailer/Providers/config.php
@@ -26,7 +26,7 @@ return [
                 'encryption'       => 'none',
                 'key_store'        => 'db'
             ],
-            'note'     => '<a href="https://fluentsmtp.com/docs/set-up-fluent-smtp-with-any-host-or-mailer/" target="_blank" rel="noopener">Read the documentation</a> for how to configure any SMTP with FluentSMTP.'
+            'note'     => '<a href="https://fluentsmtp.com/docs/set-up-fluent-smtp-with-any-host-or-mailer/" target="_blank" rel="noopener">' . __('Read the documentation', 'fluent-smtp') . '</a>' . __(' for how to configure any SMTP with FluentSMTP.', 'fluent-smtp')
         ],
         'ses'         => [
             'key'      => 'ses',

--- a/resources/admin/Modules/Dashboard/Charts/Emails.vue
+++ b/resources/admin/Modules/Dashboard/Charts/Emails.vue
@@ -55,7 +55,7 @@
                 };
 
                 const cumulativeItems = {
-                    label: 'Cumulative',
+                    label: this.$t('Cumulative'),
                     backgroundColor: 'rgba(55, 162, 235, 0.1)',
                     borderColor: '#37a2eb',
                     data: [],

--- a/resources/admin/Modules/Logger/LogFilter.vue
+++ b/resources/admin/Modules/Logger/LogFilter.vue
@@ -18,7 +18,7 @@
                     v-model="filter_query.date_range"
                     type="daterange"
                     :placeholder="$t('Select date and time')"
-                    range-separator="To"
+                    range-separator="$t('To')"
                     :start-placeholder="$t('Start date')"
                     :end-placeholder="$t('End date')"
                     style="width:100%"

--- a/resources/admin/Modules/Logger/LogViewer.vue
+++ b/resources/admin/Modules/Logger/LogViewer.vue
@@ -47,11 +47,11 @@
                         <div class="item_content">{{ log.created_at }}</div>
                     </li>
                     <li>
-                        <div class="item_header">{ $t('From:') }}:</div>
+                        <div class="item_header">{ $t('From') }}:</div>
                         <div class="item_content"><span v-html="log.from"></span></div>
                     </li>
                     <li>
-                        <div class="item_header">{ $t('To:') }}:</div>
+                        <div class="item_header">{ $t('To') }}:</div>
                         <div class="item_content">
                             <span v-html="log.to"></span>
                         </div>

--- a/resources/admin/Modules/Logger/LogViewer.vue
+++ b/resources/admin/Modules/Logger/LogViewer.vue
@@ -47,11 +47,11 @@
                         <div class="item_content">{{ log.created_at }}</div>
                     </li>
                     <li>
-                        <div class="item_header">From:</div>
+                        <div class="item_header">{ $t('From:') }}:</div>
                         <div class="item_content"><span v-html="log.from"></span></div>
                     </li>
                     <li>
-                        <div class="item_header">To:</div>
+                        <div class="item_header">{ $t('To:') }}:</div>
                         <div class="item_content">
                             <span v-html="log.to"></span>
                         </div>
@@ -69,13 +69,13 @@
                         </div>
                     </li>
                     <li v-if="log.extra && log.extra.provider && settings.providers[log.extra.provider]">
-                        <div class="item_header">Mailer:</div>
+                        <div class="item_header">{ $t('Mailer:</div>
                         <div class="item_content">
                             <span>{{ settings.providers[log.extra.provider].title }}</span>
                         </div>
                     </li>
                     <li v-else-if="log.extra && log.extra.provider">
-                        <div class="item_header">Mailer:</div>
+                        <div class="item_header">{ $t('Mailer:</div>
                         <div class="item_content">
                             <span>{{ log.extra.provider }}</span>
                         </div>

--- a/resources/admin/Modules/Logger/LogViewer.vue
+++ b/resources/admin/Modules/Logger/LogViewer.vue
@@ -47,11 +47,11 @@
                         <div class="item_content">{{ log.created_at }}</div>
                     </li>
                     <li>
-                        <div class="item_header">{ $t('From') }}:</div>
+                        <div class="item_header">{{ $t('From') }}:</div>
                         <div class="item_content"><span v-html="log.from"></span></div>
                     </li>
                     <li>
-                        <div class="item_header">{ $t('To') }}:</div>
+                        <div class="item_header">{{ $t('To') }}:</div>
                         <div class="item_content">
                             <span v-html="log.to"></span>
                         </div>
@@ -69,13 +69,13 @@
                         </div>
                     </li>
                     <li v-if="log.extra && log.extra.provider && settings.providers[log.extra.provider]">
-                        <div class="item_header">{ $t('Mailer') }}:</div>
+                        <div class="item_header">{{ $t('Mailer') }}:</div>
                         <div class="item_content">
                             <span>{{ settings.providers[log.extra.provider].title }}</span>
                         </div>
                     </li>
                     <li v-else-if="log.extra && log.extra.provider">
-                        <div class="item_header">{ $t('Mailer') }}:</div>
+                        <div class="item_header">{{ $t('Mailer') }}:</div>
                         <div class="item_content">
                             <span>{{ log.extra.provider }}</span>
                         </div>

--- a/resources/admin/Modules/Logger/LogViewer.vue
+++ b/resources/admin/Modules/Logger/LogViewer.vue
@@ -69,13 +69,13 @@
                         </div>
                     </li>
                     <li v-if="log.extra && log.extra.provider && settings.providers[log.extra.provider]">
-                        <div class="item_header">{ $t('Mailer:</div>
+                        <div class="item_header">{ $t('Mailer') }}:</div>
                         <div class="item_content">
                             <span>{{ settings.providers[log.extra.provider].title }}</span>
                         </div>
                     </li>
                     <li v-else-if="log.extra && log.extra.provider">
-                        <div class="item_header">{ $t('Mailer:</div>
+                        <div class="item_header">{ $t('Mailer') }}:</div>
                         <div class="item_content">
                             <span>{{ log.extra.provider }}</span>
                         </div>

--- a/resources/admin/Modules/Logger/Logs.vue
+++ b/resources/admin/Modules/Logger/Logs.vue
@@ -54,7 +54,7 @@
                         <template slot-scope="scope">
                             <span style="cursor: pointer" @click="handleView(scope.row)">{{ scope.row.subject }}</span>
                             <span v-if="scope.row.extra && scope.row.extra.provider == 'Simulator'"
-                                  style="color: #ff0000;"> - Simulated</span>
+                                  style="color: #ff0000;">{{ $t(' - Simulated') }}</span>
                         </template>
                     </el-table-column>
 
@@ -122,7 +122,7 @@
                         <div v-if="logs.length" style="margin-top:20px;">
                             <confirm placement="right" :message="$t('Are you sure, you want to delete all the logs?')"
                                      @yes="handleDelete(['all'])">
-                                <el-button slot="reference" size="mini" type="info">Delete All Logs</el-button>
+                                <el-button slot="reference" size="mini" type="info">{{ $t('Delete All Logs') }}</el-button>
                             </confirm>
                         </div>
                         <span v-else>&nbsp;</span>

--- a/resources/admin/Modules/Misc/Docs.vue
+++ b/resources/admin/Modules/Misc/Docs.vue
@@ -73,15 +73,15 @@
 
                 const items = {
                     item_4: {
-                        label: 'Getting Started',
+                        label: this.$t('Getting Started'),
                         docs: []
                     },
                     item_5: {
-                        label: 'Connect With Your Email Providers',
+                        label: this.$t('Connect With Your Email Providers'),
                         docs: []
                     },
                     item_6: {
-                        label: 'Functionalities',
+                        label: this.$t('Functionalities'),
                         docs: []
                     }
                 };

--- a/resources/admin/Modules/Misc/Support.vue
+++ b/resources/admin/Modules/Misc/Support.vue
@@ -57,8 +57,8 @@
             </el-col>
             <el-col :sm="24" :md="12">
                 <div v-if="plugin || installed_info">
-                    <div v-loading="installing" element-loading-text="Installing... Please wait" class="fss_about">
-                        <div class="fss_header">Recommended Plugin</div>
+                    <div v-loading="installing" element-loading-text="$t('Installing... Please wait')" class="fss_about">
+                        <div class="fss_header">{{ $t('Recommended Plugin') }}</div>
                         <div class="fss_content">
                             <div v-if="installed_info" class="install_success">
                                 <h3>{{ installed_message }}</h3>
@@ -87,7 +87,7 @@
                     </div>
                 </div>
                 <div class="fss_about">
-                    <div class="fss_header">Community</div>
+                    <div class="fss_header">{{ $t('Community') }}</div>
                     <div class="fss_content">
                         <p>{{ $t('__ABOUT_COMMUNITY') }}</p>
                         <p>{{ $t('__ABOUT_JOIN') }}</p>
@@ -100,7 +100,7 @@
                             </li>
                             <li>
                                 <a target="_blank" rel="nofollow"
-                                   href="https://wordpress.org/support/plugin/fluent-smtp/reviews/?filter=5">{{ $t('Write a review (really appreciate 😊)') }}</a>
+                                   href="https://wordpress.org/support/plugin/fluent-smtp/reviews/?filter=5">{{ $t('Write a review (really appreciated 😊)') }}</a>
                             </li>
                             <li>
                                 <a target="_blank" rel="noopener" href="http://fluentsmtp.com/docs">{{ $t('Read the documentation') }}</a>

--- a/resources/admin/Modules/NotificationSettings/NotificationManager.vue
+++ b/resources/admin/Modules/NotificationSettings/NotificationManager.vue
@@ -10,9 +10,9 @@
             <discord-notification :notification_settings="notification_settings"/>
         </template>
         <div style="text-align: center;" v-else>
-            <h3>Real-Time Email Failure Notifications</h3>
-            <p>Get real-time notification on your favorite messaging channel on any email sending failure. Configure any
-                of the following channel to start getting real time notifications.</p>
+            <h3>{{ $t('Real-Time Email Failure Notifications') }}</h3>
+            <p>{{ $t('Get real-time notification on your favorite messaging channel on any email sending failure. Configure any
+                of the following channel to start getting real time notifications.') }}</p>
 
             <div class="fss_notification_channels">
                 <div v-for="(channel, channelKey) in channels" :key="channelKey" class="fss_notification_channel">

--- a/resources/admin/Modules/NotificationSettings/_EmailSummaryForm.vue
+++ b/resources/admin/Modules/NotificationSettings/_EmailSummaryForm.vue
@@ -47,13 +47,13 @@ export default {
     data() {
         return {
             sending_days: {
-                Mon: 'Monday',
-                Tue: 'Tuesday',
-                Wed: 'Wednesday',
-                Thu: 'Thursday',
-                Fri: 'Friday',
-                Sat: 'Saturday',
-                Sun: 'Sunday'
+                Mon: this.$t('Monday'),
+                Tue: this.$t('Tuesday'),
+                Wed: this.$t('Wednesday'),
+                Thu: this.$t('Thursday'),
+                Fri: this.$t('Friday'),
+                Sat: this.$t('Saturday'),
+                Sun: this.$t('Sunday')
             },
             saving: false,
         }

--- a/resources/admin/Modules/Settings/Partials/Providers/Smtp.vue
+++ b/resources/admin/Modules/Settings/Partials/Providers/Smtp.vue
@@ -30,7 +30,7 @@
                     </label>
 
                     <div class="small-help-text" style="display:inline-block;">
-                        Select <strong>ssl</strong> on port <strong>465</strong>, or <strong>tls</strong> on port <strong>25</strong> or <strong>587</strong>
+                        {{ $t('Select <strong>ssl</strong> on port <strong>465</strong>, or <strong>tls</strong> on port <strong>25</strong> or <strong>587') }}</strong>
                     </div>
 
                     <div style="display:inline-block;margin-left: 20px;">

--- a/resources/admin/Modules/Settings/Partials/_ConnectionSelector.vue
+++ b/resources/admin/Modules/Settings/Partials/_ConnectionSelector.vue
@@ -6,7 +6,7 @@
                 <i class="fstmp_check_icon">
                     <svg fill="#000000" xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 26 26" width="26px" height="26px"><path d="M 13 1 C 6.382813 1 1 6.382813 1 13 C 1 19.617188 6.382813 25 13 25 C 19.617188 25 25 19.617188 25 13 C 25 6.382813 19.617188 1 13 1 Z M 13 3 C 18.535156 3 23 7.464844 23 13 C 23 18.535156 18.535156 23 13 23 C 7.464844 23 3 18.535156 3 13 C 3 7.464844 7.464844 3 13 3 Z M 17.1875 7.0625 C 17.039063 7.085938 16.914063 7.164063 16.8125 7.3125 L 11.90625 14.59375 L 9.59375 12.3125 C 9.394531 12.011719 9.011719 11.988281 8.8125 12.1875 L 7.90625 13.09375 C 7.707031 13.394531 7.707031 13.800781 7.90625 14 L 11.40625 17.5 C 11.605469 17.601563 11.886719 17.8125 12.1875 17.8125 C 12.386719 17.8125 12.707031 17.707031 12.90625 17.40625 L 18.90625 8.59375 C 19.105469 8.292969 18.992188 8.011719 18.59375 7.8125 L 17.59375 7.09375 C 17.492188 7.042969 17.335938 7.039063 17.1875 7.0625 Z"/></svg>                </i>
             </div>
-            <el-button @click="showAll = !showAll" size="small" icon="el-icon-edit" type="default">change</el-button>
+            <el-button @click="showAll = !showAll" size="small" icon="el-icon-edit" type="default">{{ $t('change') }}</el-button>
         </div>
         <el-radio-group @change="showAll = false" v-else class="fss_connections" v-model="connection.provider">
             <el-radio-button :class="'con_'+providerName" v-for="(provider, providerName) in providers" :key="providerName" :label="providerName">

--- a/resources/admin/Modules/Test/Test.vue
+++ b/resources/admin/Modules/Test/Test.vue
@@ -21,7 +21,7 @@
                         </span>
                     </el-form-item>
 
-                    <el-form-item for="from" label="Send To">
+                    <el-form-item for="from" label="$t('Send To')">
                         <el-input id="from" v-model="form.email" />
 
                         <span class="small-help-text" style="display:block;margin-top:-10px">
@@ -109,7 +109,7 @@
 
                 this.$post('settings/test', { ...this.form }).then(res => {
                     this.$notify.success({
-                        title: 'Great!',
+                        title: this.$t('Great!'),
                         offset: 19,
                         message: res.data.message
                     });
@@ -117,7 +117,7 @@
                 }).fail(res => {
                     if (Number(res.status) === 504) {
                         return this.$notify.error({
-                            title: 'Oops!',
+                            title: this.$t('Oops!'),
                             offset: 19,
                             message: '504 Gateway Time-out.'
                         });
@@ -127,7 +127,7 @@
 
                     if (responseJSON.data.email_error) {
                         return this.$notify.error({
-                            title: 'Oops!',
+                            title: this.$t('Oops!'),
                             offset: 19,
                             message: responseJSON.data.email_error
                         });

--- a/resources/admin/Pieces/Confirm.vue
+++ b/resources/admin/Pieces/Confirm.vue
@@ -39,7 +39,7 @@
                 default: 'top-end'
             },
             message: {
-                default: 'Are you sure to delete this?'
+                default: $t('Are you sure to delete this?')
             }
         },
         data() {

--- a/resources/admin/Pieces/Confirm.vue
+++ b/resources/admin/Pieces/Confirm.vue
@@ -39,7 +39,7 @@
                 default: 'top-end'
             },
             message: {
-                default: $t('Are you sure to delete this?')
+                default: this.$t('Are you sure to delete this?')
             }
         },
         data() {

--- a/resources/admin/Pieces/_Subscrbe.vue
+++ b/resources/admin/Pieces/_Subscrbe.vue
@@ -15,7 +15,7 @@
                 </el-form>
 
                 <el-checkbox true-label="yes" false-label="no" v-model="share_details">
-                    (Optional) Share Non - Sensitive Data.It will help us to improve the integrations
+                    {{ $t('(Optional) Share Non - Sensitive Data.It will help us to improve the integrations') }}
                     <el-tooltip class="item" effect="dark" content="Access Data: Active SMTP Connection Provider, installed plugin names, php & mysql version" placement="top-end">
                         <i class="el-icon el-icon-info"></i>
                     </el-tooltip>

--- a/resources/admin/Pieces/_Subscrbe.vue
+++ b/resources/admin/Pieces/_Subscrbe.vue
@@ -16,7 +16,7 @@
 
                 <el-checkbox true-label="yes" false-label="no" v-model="share_details">
                     {{ $t('(Optional) Share Non - Sensitive Data.It will help us to improve the integrations') }}
-                    <el-tooltip class="item" effect="dark" content="Access Data: Active SMTP Connection Provider, installed plugin names, php & mysql version" placement="top-end">
+                    <el-tooltip class="item" effect="dark" content="$t('Access Data: Active SMTP Connection Provider, installed plugin names, php & mysql version')" placement="top-end">
                         <i class="el-icon el-icon-info"></i>
                     </el-tooltip>
                 </el-checkbox>


### PR DESCRIPTION
This PR improves the localization functionality of multiple strings so that they are translatable (and will appear on translate.wordpress.org).  Some strings still show in English only in the frontend of the plugin

Please check my code if I made any errors and I try to contribute more if I find more strings.
Thanks!