### PR TITLE
Add name to attachment file

### DIFF
--- a/app/Functions/helpers.php
+++ b/app/Functions/helpers.php
@@ -571,15 +571,17 @@
             }
 
 
-            if (!empty($attachments)) {
-                foreach ($attachments as $attachment) {
-                    try {
-                        $phpmailer->addAttachment($attachment);
-                    } catch (PHPMailer\PHPMailer\Exception $e) {
-                        continue;
-                    }
-                }
-            }
+            if ( ! empty( $attachments ) ) {
+        		foreach ( $attachments as $filename => $attachment ) {
+        			$filename = is_string( $filename ) ? $filename : '';
+        
+        			try {
+        				$phpmailer->addAttachment( $attachment, $filename );
+        			} catch ( PHPMailer\PHPMailer\Exception $e ) {
+        				continue;
+        			}
+        		}
+        	}
 
             /**
              * Fires after PHPMailer is initialized.


### PR DESCRIPTION
By using this code the user can use an associative array for $attachment. $key is used as filename, while $value is the path. Will not cause issues for users that used indexed arrays. Took the code from native wp_mail and inserted it here. Worked well by testing on my machine.