### PR TITLE
Update error handling of BaseHandler

### DIFF
--- a/app/Services/Mailer/BaseHandler.php
+++ b/app/Services/Mailer/BaseHandler.php
@@ -267,7 +267,7 @@ class BaseHandler
             $errorResponse = [
                 'code'    => $code,
                 'message' => $message,
-                'errors'  => $response->get_error_messages()
+                'errors'  => $response->get_error_data()
             ];
 
             $this->processResponse($errorResponse, false);


### PR DESCRIPTION
`get_error_messages()` is basically the same message as `$message`, while `get_error_data()` provides useful information why an API call has an error. Most providers already put the response data as the WP_Error data, so no other changes should be necessary.  