### PR TITLE
Add ap-northeast-3 (Asia Pacific (Osaka)) region

### DIFF
--- a/app/Services/Mailer/Providers/config.php
+++ b/app/Services/Mailer/Providers/config.php
@@ -61,6 +61,7 @@ return [
                 'ap-southeast-1' => __('Asia Pacific (Singapore)', 'fluent-smtp'),
                 'ap-southeast-2' => __('Asia Pacific (Sydney)', 'fluent-smtp'),
                 'ap-northeast-1' => __('Asia Pacific (Tokyo)', 'fluent-smtp'),
+                'ap-northeast-3' => __('Asia Pacific (Osaka)', 'fluent-smtp'),
                 'sa-east-1'      => __('South America (São Paulo)', 'fluent-smtp'),
                 'me-south-1'     => __('Middle East (Bahrain)', 'fluent-smtp'),
                 'us-gov-west-1'  => __('AWS GovCloud (US)', 'fluent-smtp'),

--- a/language/fluent-smtp.pot
+++ b/language/fluent-smtp.pot
@@ -32,7 +32,7 @@ msgstr ""
 msgid " connection."
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:70
+#: app/Services/Mailer/Providers/config.php:71
 msgid " for how to configure Amazon SES with FluentSMTP."
 msgstr ""
 
@@ -40,31 +40,31 @@ msgstr ""
 msgid " for how to configure any SMTP with FluentSMTP."
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:175
+#: app/Services/Mailer/Providers/config.php:176
 msgid " for how to configure Elastic Email with FluentSMTP."
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:87
+#: app/Services/Mailer/Providers/config.php:88
 msgid " for how to configure Mailgun with FluentSMTP."
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:143
+#: app/Services/Mailer/Providers/config.php:144
 msgid " for how to configure Netcore (formerly Pepipost) with FluentSMTP."
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:160
+#: app/Services/Mailer/Providers/config.php:161
 msgid " for how to configure Postmark with FluentSMTP."
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:101
+#: app/Services/Mailer/Providers/config.php:102
 msgid " for how to configure SendGrid with FluentSMTP."
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:115
+#: app/Services/Mailer/Providers/config.php:116
 msgid " for how to configure Sendinblue with FluentSMTP."
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:129
+#: app/Services/Mailer/Providers/config.php:130
 msgid " for how to configure SparkPost with FluentSMTP."
 msgstr ""
 
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Add Multi-Part Plain Text for HTML Emails (beta)"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:67
+#: app/Services/Mailer/Providers/config.php:68
 msgid "Africa (Cape Town)"
 msgstr ""
 
@@ -379,6 +379,10 @@ msgstr ""
 msgid "Asia Pacific (Tokyo)"
 msgstr ""
 
+#: app/Services/Mailer/Providers/config.php:64
+msgid "Asia Pacific (Osaka)"
+msgstr ""
+
 #: app/Services/TransStrings.php:56
 msgid "Attachments"
 msgstr ""
@@ -419,7 +423,7 @@ msgstr ""
 msgid "Awesome! You are redirecting to slack"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:66
+#: app/Services/Mailer/Providers/config.php:67
 msgid "AWS GovCloud (US)"
 msgstr ""
 
@@ -463,7 +467,7 @@ msgstr ""
 msgid "check the documentation first to create API keys at Microsoft"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:68
+#: app/Services/Mailer/Providers/config.php:69
 msgid "China (Ningxia)"
 msgstr ""
 
@@ -663,7 +667,7 @@ msgstr ""
 msgid "Edit Connection"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:164
+#: app/Services/Mailer/Providers/config.php:165
 msgid "Elastic Email"
 msgstr ""
 
@@ -1081,11 +1085,11 @@ msgstr ""
 msgid "Gmail / Google Workspace API Settings"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:192
+#: app/Services/Mailer/Providers/config.php:193
 msgid "Gmail or Google Workspace"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:207
+#: app/Services/Mailer/Providers/config.php:208
 msgid ""
 "Gmail/Google Workspace is not recommended for sending mass marketing emails."
 msgstr ""
@@ -1347,7 +1351,7 @@ msgstr ""
 msgid "Mailer"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:74
+#: app/Services/Mailer/Providers/config.php:75
 msgid "Mailgun"
 msgstr ""
 
@@ -1384,7 +1388,7 @@ msgstr ""
 msgid "Message Stream"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:65
+#: app/Services/Mailer/Providers/config.php:66
 msgid "Middle East (Bahrain)"
 msgstr ""
 
@@ -1400,7 +1404,7 @@ msgstr ""
 msgid "More information on Mailgun.com"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:133
+#: app/Services/Mailer/Providers/config.php:134
 msgid "Netcore Email API, formerly Pepipost"
 msgstr ""
 
@@ -1453,11 +1457,11 @@ msgstr ""
 msgid "Outlook / Office365 API Settings"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:211
+#: app/Services/Mailer/Providers/config.php:212
 msgid "Outlook or Office 365"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:226
+#: app/Services/Mailer/Providers/config.php:227
 msgid "Outlook/Office365 is not recommended for sending mass marketing emails."
 msgstr ""
 
@@ -1465,7 +1469,7 @@ msgstr ""
 msgid "Pepipost API Settings"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:230
+#: app/Services/Mailer/Providers/config.php:231
 msgid "PHP mail()"
 msgstr ""
 
@@ -1649,7 +1653,7 @@ msgstr ""
 msgid "Possible Conflict: "
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:147
+#: app/Services/Mailer/Providers/config.php:148
 msgid "Postmark"
 msgstr ""
 
@@ -1691,14 +1695,14 @@ msgstr ""
 
 #: app/Services/TransStrings.php:195
 #: app/Services/Mailer/Providers/config.php:29
-#: app/Services/Mailer/Providers/config.php:70
-#: app/Services/Mailer/Providers/config.php:87
-#: app/Services/Mailer/Providers/config.php:101
-#: app/Services/Mailer/Providers/config.php:115
-#: app/Services/Mailer/Providers/config.php:129
-#: app/Services/Mailer/Providers/config.php:143
-#: app/Services/Mailer/Providers/config.php:160
-#: app/Services/Mailer/Providers/config.php:175
+#: app/Services/Mailer/Providers/config.php:71
+#: app/Services/Mailer/Providers/config.php:88
+#: app/Services/Mailer/Providers/config.php:102
+#: app/Services/Mailer/Providers/config.php:116
+#: app/Services/Mailer/Providers/config.php:130
+#: app/Services/Mailer/Providers/config.php:144
+#: app/Services/Mailer/Providers/config.php:161
+#: app/Services/Mailer/Providers/config.php:176
 msgid "Read the documentation"
 msgstr ""
 
@@ -1872,7 +1876,7 @@ msgstr ""
 msgid "Sender Settings"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:91
+#: app/Services/Mailer/Providers/config.php:92
 msgid "SendGrid"
 msgstr ""
 
@@ -1880,7 +1884,7 @@ msgstr ""
 msgid "SendGrid API Settings"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:105
+#: app/Services/Mailer/Providers/config.php:106
 msgid "Sendinblue"
 msgstr ""
 
@@ -2007,7 +2011,7 @@ msgstr ""
 msgid "SMTP/Mail Settings"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:179
+#: app/Services/Mailer/Providers/config.php:180
 msgid "SMTP2GO"
 msgstr ""
 
@@ -2062,11 +2066,11 @@ msgstr ""
 msgid "Sorry, You can not install this plugin"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:64
+#: app/Services/Mailer/Providers/config.php:65
 msgid "South America (São Paulo)"
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:119
+#: app/Services/Mailer/Providers/config.php:120
 msgid "SparkPost"
 msgstr ""
 
@@ -2187,7 +2191,7 @@ msgid ""
 "you face while creating tables on your posts/pages."
 msgstr ""
 
-#: app/Services/Mailer/Providers/config.php:241
+#: app/Services/Mailer/Providers/config.php:242
 msgid ""
 "The Default option does not use SMTP or any Email Service Providers so it "
 "will not improve email delivery on your site."


### PR DESCRIPTION
Added ap-northeast-3, Asia Pacific (Osaka) regions for Amazon SES.

closes #304 