### PR TITLE
PHP 8.4 support for class FluentMail\App\Services\Mailer\Manager;

### DIFF
--- a/app/Services/Mailer/Manager.php
+++ b/app/Services/Mailer/Manager.php
@@ -21,7 +21,7 @@ class Manager
     
     protected static $wpConfigSettings = [];
 
-    public function __construct(Application $app = null)
+    public function __construct(?Application $app = null)
     {
         $this->app = $app ?: fluentMail();
 


### PR DESCRIPTION
Add explicit nullable type to __construct $app;