### PR TITLE
fix:removed-sendgrid-validator-from-smtp2go-handler

### DIFF
--- a/app/Services/Mailer/Providers/Smtp2Go/Handler.php
+++ b/app/Services/Mailer/Providers/Smtp2Go/Handler.php
@@ -7,7 +7,7 @@ use FluentMail\Includes\Support\Arr;
 use FluentMail\Includes\Core\Application;
 use FluentMail\App\Services\Mailer\Manager;
 use FluentMail\App\Services\Mailer\BaseHandler;
-use FluentMail\App\Services\Mailer\Providers\SendGrid\ValidatorTrait;
+use FluentMail\App\Services\Mailer\Providers\Smtp2Go\ValidatorTrait;
 
 class Handler extends BaseHandler {
     use ValidatorTrait;


### PR DESCRIPTION
Updated the import statement in `app/Services/Mailer/Providers/Smtp2Go/Handler.php` to use `Smtp2Go\ValidatorTrait` instead of `SendGrid\ValidatorTrait`, ensuring the correct validation trait is used for the SMTP2Go handler.