### PR TITLE
fix-resend-attachments-error-&-styling-fix-&fix-redundant-navigation-error

### DIFF
--- a/resources/admin/Modules/Logger/Logs.vue
+++ b/resources/admin/Modules/Logger/Logs.vue
@@ -76,7 +76,7 @@
                         </template>
                     </el-table-column>
 
-                    <el-table-column :label="$t('Actions')" width="190px" align="right">
+                    <el-table-column :label="$t('Actions')" width="200px" align="right">
                         <template slot-scope="scope">
                             <el-button
                                 size="mini"
@@ -201,7 +201,11 @@ export default {
                 search: this.filter_query.search
             };
 
-            this.$router.replace({query: data});
+            this.$router.replace({ query: data }).catch(err => {
+              if (err.name !== 'NavigationDuplicated') {
+                console.error(err);
+              }
+            });
 
             this.$get('logs', data).then(res => {
                 this.logs = this.formatLogs(res.data);


### PR DESCRIPTION
- Fix: Prevent redundant navigation error in Logs screen when refreshing
- Fix: Prevent resend errors when attachments are logged as arrays
- Fix: Styling Fix for Logs Screens

<img width="1895" height="973" alt="image" src="https://github.com/user-attachments/assets/ec76261d-8540-4ae8-8b13-910ee561180b" />

<img width="1901" height="981" alt="image" src="https://github.com/user-attachments/assets/10ba94cf-9969-47ec-8ecc-d4137ce46c37" />
