### PR TITLE
PHP 8.4 support: DB/Connection, DB/QueryBuilder/QueryBuilderHandler and Mailer/BaseHandler;

### DIFF
--- a/app/Services/DB/Connection.php
+++ b/app/Services/DB/Connection.php
@@ -47,7 +47,7 @@ class Connection
      * @param null|string    $alias
      * @param null|Container $container
      */
-    public function __construct($wpdb, array $config = array(), $alias = null, Container $container = null)
+    public function __construct($wpdb, array $config = array(), $alias = null, ?Container $container = null)
     {
         $container = $container ? : new Container();
 

--- a/app/Services/DB/QueryBuilder/QueryBuilderHandler.php
+++ b/app/Services/DB/QueryBuilder/QueryBuilderHandler.php
@@ -61,7 +61,7 @@ class QueryBuilderHandler
      *
      * @throws \FluentMail\App\Services\DB\Exception
      */
-    public function __construct(Connection $connection = null)
+    public function __construct(?Connection $connection = null)
     {
         if (is_null($connection)) {
             if (! $connection = Connection::getStoredConnection()) {
@@ -117,7 +117,7 @@ class QueryBuilderHandler
      *
      * @return static
      */
-    public function newQuery(Connection $connection = null)
+    public function newQuery(?Connection $connection = null)
     {
         if (is_null($connection)) {
             $connection = $this->connection;

--- a/app/Services/Mailer/BaseHandler.php
+++ b/app/Services/Mailer/BaseHandler.php
@@ -30,7 +30,7 @@ class BaseHandler
 
     protected $existing_row_id = null;
 
-    public function __construct(Application $app = null, Manager $manager = null)
+    public function __construct(?Application $app = null, ?Manager $manager = null)
     {
         $this->app = $app ?: fluentMail();
         $this->manager = $manager ?: fluentMail(Manager::class);


### PR DESCRIPTION
Just small changes

1. app/Services/DB/Connection.php 
    Add explicit nullable type to __construct() param $container;
2. app/Services/DB/QueryBuilder/QueryBuilderHandler.php
   Add explicit nullable type to __construct() param $connection;
   Add explicit nullable type to newQuery()  param $connection;
3. app/Services/Mailer/BaseHandler.php
    Add explicit nullable type to __construct() params $app and $manager;

