### PR TITLE
Version 2.2.92

### DIFF
--- a/app/Services/Mailer/Providers/Simulator/Handler.php
+++ b/app/Services/Mailer/Providers/Simulator/Handler.php
@@ -18,6 +18,9 @@ class Handler extends BaseHandler
                 $headers[$customHeader['key']] = $customHeader['value'];
             }
 
+            $headers = $this->phpMailer->getCustomHeaders();
+            $headers['content-type'] = $this->phpMailer->ContentType;
+
             $logData = [
                 'to' => maybe_serialize($this->setRecipientsArray($this->phpMailer->getToAddresses())),
                 'from' => maybe_serialize($this->phpMailer->From),
@@ -26,7 +29,7 @@ class Handler extends BaseHandler
                 'attachments' => maybe_serialize($this->phpMailer->getAttachments()),
                 'status'   => 'sent',
                 'response' => maybe_serialize(['status' => __('Email sending was simulated, No Email was sent originally', 'fluent-smtp')]),
-                'headers'  => maybe_serialize($this->phpMailer->getCustomHeaders()),
+                'headers'  => maybe_serialize($headers),
                 'extra'    => maybe_serialize(['provider' => 'Simulator'])
             ];
 

--- a/boot.php
+++ b/boot.php
@@ -3,7 +3,7 @@
 !defined('WPINC') && die;
 
 define('FLUENTMAIL', 'fluentmail');
-define('FLUENTMAIL_PLUGIN_VERSION', '2.2.90');
+define('FLUENTMAIL_PLUGIN_VERSION', '2.2.92');
 define('FLUENTMAIL_UPLOAD_DIR', '/fluentmail');
 define('FLUENT_MAIL_DB_PREFIX', 'fsmpt_');
 define('FLUENTMAIL_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/fluent-smtp.php
+++ b/fluent-smtp.php
@@ -3,7 +3,7 @@
 Plugin Name:  FluentSMTP
 Plugin URI:   https://fluentsmtp.com
 Description:  The Ultimate SMTP Connection Plugin for WordPress.
-Version:      2.2.90
+Version:      2.2.92
 Author:       FluentSMTP & WPManageNinja Team
 Author URI:   https://fluentsmtp.com
 License:      GPL2

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: techjewel, wpmanageninja, heera, adreastrian
 Tags: smtp, amazon ses, wordpress mail smtp, mail, mail smtp
 Requires at least: 5.5
 Tested up to: 6.7
-Stable tag: 2.2.90
+Stable tag: 2.2.92
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -294,6 +294,19 @@ We use Patchstack to manage our security report. <a href="https://patchstack.com
 
 
 == Changelog ==
+
+= 2.2.92 (Date: Aug 27, 2025) =
+- Fixed attachment handling issue with Elastic Email.
+- Resolved import statement issue for SMTP2GO.
+- Added PHP 8.4 support for FluentMail\App\Services\Mailer\Manager.
+- Added new Amazon SES region: ap-northeast-3 (Asia Pacific – Osaka).
+- Improved error handling in BaseHandler.
+- Updated fallback email handling to return true on success.
+- General bug fixes and performance improvements.
+- Fix: Logger Resend Email respects Content-Type for HTML emails
+- Styling Improvements
+- Fix: Prevent redundant navigation error in Logs screen when refreshing
+- Fix: Ensure Content-Type header is always logged for accurate email resends
 
 = 2.2.90 (Date: Feb 07, 2025) =
 - Added SMTP2GO Provider

--- a/resources/admin/Modules/Dashboard/Dashboard.vue
+++ b/resources/admin/Modules/Dashboard/Dashboard.vue
@@ -41,7 +41,7 @@
                                     :end-placeholder="$t('End date')"
                                     value-format="yyyy-MM-dd"
                                 ></el-date-picker>
-                                <el-button size="small" @click="filterReport" type="primary" plain>Apply</el-button>
+                                <el-button style="padding: 8px 15px;" size="small" @click="filterReport" type="primary" plain>Apply</el-button>
                             </div>
                         </div>
                         <div class="fss_content">

--- a/resources/admin/Modules/Logger/Logs.vue
+++ b/resources/admin/Modules/Logger/Logs.vue
@@ -76,7 +76,7 @@
                         </template>
                     </el-table-column>
 
-                    <el-table-column :label="$t('Actions')" width="190px" align="right">
+                    <el-table-column :label="$t('Actions')" width="200px" align="right">
                         <template slot-scope="scope">
                             <el-button
                                 size="mini"
@@ -201,7 +201,11 @@ export default {
                 search: this.filter_query.search
             };
 
-            this.$router.replace({query: data});
+            this.$router.replace({ query: data }).catch(err => {
+              if (err.name !== 'NavigationDuplicated') {
+                console.error(err);
+              }
+            });
 
             this.$get('logs', data).then(res => {
                 this.logs = this.formatLogs(res.data);

--- a/resources/admin/Pieces/_Subscrbe.vue
+++ b/resources/admin/Pieces/_Subscrbe.vue
@@ -15,7 +15,7 @@
                 </el-form>
 
                 <el-checkbox true-label="yes" false-label="no" v-model="share_details">
-                    {{ $t('(Optional) Share Non - Sensitive Data.It will help us to improve the integrations') }}
+                    {{ $t('(Optional) Share Non - Sensitive Data. It will help us to improve the integrations') }}
                     <el-tooltip class="item" effect="dark" :content="$t('Access Data: Active SMTP Connection Provider, installed plugin names, php & mysql version')" placement="top-end">
                         <i class="el-icon el-icon-info"></i>
                     </el-tooltip>


### PR DESCRIPTION
### **Version 2.2.92.** 

**_= 2.2.92 (Date: Aug 27, 2025) =_**
- Fixed attachment handling issue with Elastic Email.
- Resolved import statement issue for SMTP2GO.
- Added PHP 8.4 support for FluentMail\App\Services\Mailer\Manager.
- Added new Amazon SES region: ap-northeast-3 (Asia Pacific – Osaka).
- Improved error handling in BaseHandler.
- Updated fallback email handling to return true on success.
- General bug fixes and performance improvements.
- Fix: Logger Resend Email respects Content-Type for HTML emails
- Styling Improvements
- Fix: Prevent redundant navigation error in Logs screen when refreshing
- Fix: Ensure Content-Type header is always logged for accurate email resends