### PR TITLE
updated mailgun domain and api link

### DIFF
--- a/resources/admin/Modules/Settings/Partials/Providers/MailGun.vue
+++ b/resources/admin/Modules/Settings/Partials/Providers/MailGun.vue
@@ -24,7 +24,7 @@
                         {{ $t('Follow this link to get an API Key from Mailgun:') }}
                         <a
                             target="_blank"
-                            href="https://app.mailgun.com/app/account/security/api_keys"
+                            href="https://app.mailgun.com/settings/api_security"
                         >{{ $t('Get a Private API Key.') }}</a>
                     </span>
                 </el-form-item>
@@ -41,7 +41,7 @@
 
                     <span class="small-help-text">
                         {{ $t('Follow this link to get a Domain Name from Mailgun:') }}
-                        <a target="_blank" href="https://app.mailgun.com/app/domains">
+                        <a target="_blank" href="https://app.mailgun.com/mg/sending/domains">
                             {{ $t('Get a Domain Name.') }}
                         </a>
                     </span>


### PR DESCRIPTION
Previous - get the domain link, and the api link doesn't work anymore
<img width="1107" height="232" alt="image" src="https://github.com/user-attachments/assets/95bf25ef-3d10-42f6-a3c0-a2c568dcf11f" />
<img width="1495" height="312" alt="image" src="https://github.com/user-attachments/assets/22479414-b1a0-4017-8d97-b9d7e2baf3a0" />
