### PR TITLE
Add feature to choose which email to resend emails from the log

### DIFF
--- a/app/Http/Controllers/LoggerController.php
+++ b/app/Http/Controllers/LoggerController.php
@@ -63,10 +63,29 @@ class LoggerController extends Controller
                 ], $response->get_error_code());
             });
 
-            if ($email = $logger->resendEmailFromLog($request->get('id'), $request->get('type'))) {
+            $recipients = $this->sanitizeRecipients($request->get('recipients'));
+
+            $resentEmail = $logger->resendEmailFromLog(
+                $request->get('id'),
+                $request->get('type'),
+                $recipients
+            );
+
+            if ($resentEmail) {
+                $message = __('Email sent successfully.', 'fluent-smtp');
+
+                if (!empty($recipients)) {
+                    $message = sprintf(
+                        /* translators: %s: comma separated list of email addresses */
+                        __('Email sent successfully to %s.', 'fluent-smtp'),
+                        implode(', ', $recipients)
+                    );
+                }
+
                 return $this->sendSuccess([
-                    'email' => $email,
-                    'message' => __('Email sent successfully.', 'fluent-smtp')
+                    'email'      => $resentEmail,
+                    'recipients' => $recipients,
+                    'message'    => $message
                 ]);
             }
 
@@ -77,6 +96,55 @@ class LoggerController extends Controller
                 'message' => $e->getMessage()
             ], $e->getCode());
         }
+    }
+
+    /**
+     * Sanitize and validate a list of recipient email addresses coming
+     * from the resend dialog. Returns an array of valid email addresses
+     * or an empty array when none are provided / valid.
+     *
+     * @param  mixed $rawRecipients
+     * @return array<int, string>
+     * @throws \Exception When an invalid email address is supplied.
+     */
+    protected function sanitizeRecipients($rawRecipients)
+    {
+        if (empty($rawRecipients)) {
+            return [];
+        }
+
+        if (is_string($rawRecipients)) {
+            $rawRecipients = preg_split('/[\s,;]+/', $rawRecipients);
+        }
+
+        if (!is_array($rawRecipients)) {
+            return [];
+        }
+
+        $recipients = [];
+
+        foreach ($rawRecipients as $recipient) {
+            $recipient = sanitize_email(trim((string) $recipient));
+
+            if ($recipient === '') {
+                continue;
+            }
+
+            if (!is_email($recipient)) {
+                throw new \Exception(
+                    sprintf(
+                        /* translators: %s: email address */
+                        esc_html__('Invalid email address: %s', 'fluent-smtp'),
+                        esc_html($recipient)
+                    ),
+                    422
+                );
+            }
+
+            $recipients[] = $recipient;
+        }
+
+        return array_values(array_unique($recipients));
     }
 
     public function retryBulk(Request $request, Logger $logger)

--- a/app/Models/Logger.php
+++ b/app/Models/Logger.php
@@ -329,7 +329,7 @@ class Logger extends Model
         return (array)$row;
     }
 
-    public function resendEmailFromLog($id, $type = 'retry')
+    public function resendEmailFromLog($id, $type = 'retry', $recipients = [])
     {
         $email = $this->find($id);
 
@@ -358,9 +358,18 @@ class Logger extends Model
             }
         }
 
+        // When custom recipients are provided, drop cc/bcc headers so the email
+        // is only delivered to the requested address(es).
+        $hasCustomRecipients = !empty($recipients) && is_array($recipients);
+        $skipHeaderKeys = $hasCustomRecipients ? ['cc', 'bcc'] : [];
+
         $headers = [];
 
         foreach ($email['headers'] as $key => $value) {
+
+            if (in_array(strtolower((string) $key), $skipHeaderKeys, true)) {
+                continue;
+            }
 
             if($key == 'content-type' && $value == 'multipart/alternative') {
                 $value = 'text/html';
@@ -389,12 +398,16 @@ class Logger extends Model
             'From: ' . $email['from']
         ]);
 
-        $to = [];
-        foreach ($email['to'] as $recipient) {
-            if (isset($recipient['name'])) {
-                $to[] = $recipient['name'] . ' <' . $recipient['email'] . '>';
-            } else {
-                $to[] = $recipient['email'];
+        if ($hasCustomRecipients) {
+            $to = array_values($recipients);
+        } else {
+            $to = [];
+            foreach ($email['to'] as $recipient) {
+                if (isset($recipient['name'])) {
+                    $to[] = $recipient['name'] . ' <' . $recipient['email'] . '>';
+                } else {
+                    $to[] = $recipient['email'];
+                }
             }
         }
 

--- a/resources/admin/Modules/Logger/LogViewer.vue
+++ b/resources/admin/Modules/Logger/LogViewer.vue
@@ -34,7 +34,7 @@
                                     size="mini"
                                     type="success"
                                     icon="el-icon-refresh-right"
-                                    @click="handleRetry(log, 'resend')"
+                                    @click="handleResendClick"
                                     v-if="log.status == 'sent'"
                                 >
                                     {{ $t('Resend') }}
@@ -150,23 +150,37 @@
                 </el-row>
             </div>
         </el-dialog>
+
+        <ResendDialog
+            v-model="resendDialog.visible"
+            :log="resendDialog.log"
+            :resending="resendDialog.resending"
+            @confirm="handleResendConfirm"
+            @closed="handleResendDialogClosed"
+        />
     </div>
 </template>
 
 <script>
 import EmailbodyContainer from './EmailbodyContainer';
+import ResendDialog from './ResendDialog';
 
 export default {
     name: 'LogViewer',
     props: ['logViewerProps'],
-    components: {EmailbodyContainer},
+    components: {EmailbodyContainer, ResendDialog},
     data() {
         return {
             activeName: 'email_body',
             loading: false,
             next: false,
             prev: false,
-            retrying: false
+            retrying: false,
+            resendDialog: {
+                visible: false,
+                log: null,
+                resending: false
+            }
         };
     },
     methods: {
@@ -218,16 +232,28 @@ export default {
             name = name[0].replace(/\\/g, '/');
             return name.split('/').pop();
         },
-        handleRetry(log, type) {
+        handleRetry(log, type, recipients = null) {
             this.retrying = true;
-            this.$post('logs/retry', {
+
+            const payload = {
                 id: log.id,
                 type: type
-            }).then(res => {
+            };
+
+            if (recipients && recipients.length) {
+                payload.recipients = recipients;
+            }
+
+            return this.$post('logs/retry', payload).then(res => {
                 this.logViewerProps.retries = res.data.email.retries;
                 this.logViewerProps.log.status = res.data.email.status;
                 this.logViewerProps.log.updated_at = res.data.email.updated_at;
                 this.logViewerProps.log.resent_count = res.data.email.resent_count;
+                this.$notify.success({
+                    offset: 19,
+                    title: 'Great!',
+                    message: res.data.message
+                });
             }).fail(error => {
                 this.$notify.error({
                     offset: 19,
@@ -237,6 +263,29 @@ export default {
             }).always(() => {
                 this.retrying = false;
             });
+        },
+        handleResendClick() {
+            this.resendDialog.log = this.log;
+            this.resendDialog.resending = false;
+            this.resendDialog.visible = true;
+        },
+        handleResendConfirm(payload) {
+            const log = this.resendDialog.log;
+            if (!log) {
+                return;
+            }
+
+            const recipients = payload.target === 'original' ? null : payload.recipients;
+
+            this.resendDialog.resending = true;
+            this.handleRetry(log, 'resend', recipients).always(() => {
+                this.resendDialog.resending = false;
+                this.resendDialog.visible = false;
+            });
+        },
+        handleResendDialogClosed() {
+            this.resendDialog.log = null;
+            this.resendDialog.resending = false;
         },
         sanitize(html) {
             return window.DOMPurify.sanitize(html);

--- a/resources/admin/Modules/Logger/Logs.vue
+++ b/resources/admin/Modules/Logger/Logs.vue
@@ -91,7 +91,7 @@
                                 size="mini"
                                 type="success"
                                 icon="el-icon-refresh-right"
-                                @click="handleRetry(scope.row, 'resend')"
+                                @click="handleResendClick(scope.row)"
                                 v-if="scope.row.status == 'sent'"
                             >
                                 {{ $t('Resend') }}
@@ -137,6 +137,14 @@
             <el-skeleton :animated="true" v-else class="fss_content" :rows="15"></el-skeleton>
 
             <LogViewer :logViewerProps="logViewerProps"/>
+
+            <ResendDialog
+                v-model="resendDialog.visible"
+                :log="resendDialog.log"
+                :resending="resendDialog.resending"
+                @confirm="handleResendConfirm"
+                @closed="handleResendDialogClosed"
+            />
         </div>
     </div>
 </template>
@@ -147,6 +155,7 @@ import Pagination from '@/Pieces/Pagination';
 import LogFilter from './LogFilter';
 import LogViewer from './LogViewer';
 import LogBulkAction from './BulkAction';
+import ResendDialog from './ResendDialog';
 import isEmpty from 'lodash/isEmpty'
 
 export default {
@@ -156,7 +165,8 @@ export default {
         Pagination,
         LogFilter,
         LogViewer,
-        LogBulkAction
+        LogBulkAction,
+        ResendDialog
     },
     data() {
         return {
@@ -168,6 +178,11 @@ export default {
             logViewerProps: {
                 log: null,
                 dialogVisible: false
+            },
+            resendDialog: {
+                visible: false,
+                log: null,
+                resending: false
             },
             pagination: {
                 total: 0,
@@ -277,12 +292,19 @@ export default {
                 return this.handleResendBulk(this.selectedLogs);
             }
         },
-        handleRetry(row, type) {
+        handleRetry(row, type, recipients = null) {
             this.loading = true;
-            this.$post('logs/retry', {
+
+            const payload = {
                 id: row.id,
                 type: type
-            }).then(res => {
+            };
+
+            if (recipients && recipients.length) {
+                payload.recipients = recipients;
+            }
+
+            return this.$post('logs/retry', payload).then(res => {
                 if (!res.data.email) {
                     this.$notify.error({
                         offset: 19,
@@ -300,15 +322,40 @@ export default {
                     title: 'Great!',
                     message: res.data.message
                 });
+                return true;
             }).fail(error => {
                 this.$notify.error({
                     offset: 19,
                     title: 'Oops!!',
                     message: error.responseJSON.data.message
                 });
+                return false;
             }).always(() => {
                 this.loading = false;
             });
+        },
+        handleResendClick(row) {
+            this.resendDialog.log = row;
+            this.resendDialog.resending = false;
+            this.resendDialog.visible = true;
+        },
+        handleResendConfirm(payload) {
+            const row = this.resendDialog.log;
+            if (!row) {
+                return;
+            }
+
+            const recipients = payload.target === 'original' ? null : payload.recipients;
+
+            this.resendDialog.resending = true;
+            this.handleRetry(row, 'resend', recipients).always(() => {
+                this.resendDialog.resending = false;
+                this.resendDialog.visible = false;
+            });
+        },
+        handleResendDialogClosed() {
+            this.resendDialog.log = null;
+            this.resendDialog.resending = false;
         },
         handleView(row) {
             this.logViewerProps.log = row;

--- a/resources/admin/Modules/Logger/ResendDialog.vue
+++ b/resources/admin/Modules/Logger/ResendDialog.vue
@@ -32,8 +32,7 @@
                         <el-radio
                             label="self"
                             style="display:block;margin:6px 0;"
-                        >
-                            {{ $t('My account email') }}
+                        >{{ $t('My account email') }}
                             <span v-if="appVars.user_email" style="color:#909399;">
                                 ({{ appVars.user_email }})
                             </span>

--- a/resources/admin/Modules/Logger/ResendDialog.vue
+++ b/resources/admin/Modules/Logger/ResendDialog.vue
@@ -1,0 +1,218 @@
+<template>
+    <el-dialog
+        :title="$t('Resend Email')"
+        :visible.sync="visible"
+        @closed="handleClosed"
+        :close-on-click-modal="false"
+        append-to-body
+        width="480px"
+        custom-class="fss_resend_dialog"
+    >
+        <div v-if="log" v-loading="resending">
+            <p style="margin-top:0;">
+                <strong>{{ $t('Subject') }}:</strong> {{ log.subject }}
+            </p>
+            <p>
+                <strong>{{ $t('Original recipient(s)') }}:</strong>
+                <span v-html="formatOriginalRecipients(log.to)"></span>
+            </p>
+
+            <el-form
+                ref="form"
+                label-position="top"
+                :model="form"
+                @submit.native.prevent
+            >
+                <el-form-item :label="$t('Send this email to:')">
+                    <el-radio-group v-model="form.target" style="display:block;">
+                        <el-radio
+                            label="original"
+                            style="display:block;margin:6px 0;"
+                        >{{ $t('Original recipient(s)') }}</el-radio>
+                        <el-radio
+                            label="self"
+                            style="display:block;margin:6px 0;"
+                        >
+                            {{ $t('My account email') }}
+                            <span v-if="appVars.user_email" style="color:#909399;">
+                                ({{ appVars.user_email }})
+                            </span>
+                        </el-radio>
+                        <el-radio
+                            label="custom"
+                            style="display:block;margin:6px 0;"
+                        >{{ $t('A different email address') }}</el-radio>
+                    </el-radio-group>
+                </el-form-item>
+
+                <el-form-item v-if="form.target === 'custom'">
+                    <el-input
+                        ref="customInput"
+                        type="text"
+                        v-model="form.customEmail"
+                        :placeholder="$t('e.g. you@example.com')"
+                        @keyup.enter.native="handleConfirm"
+                        autocomplete="off"
+                        data-bwignore
+                        data-lpignore="true"
+                        data-1p-ignore
+                    />
+                    <span class="small-help-text" style="display:block;margin-top:4px;">
+                        {{ $t('Separate multiple email addresses with commas.') }}
+                    </span>
+                </el-form-item>
+            </el-form>
+        </div>
+
+        <span slot="footer" class="dialog-footer">
+            <el-button size="small" @click="visible = false" :disabled="resending">
+                {{ $t('Cancel') }}
+            </el-button>
+            <el-button
+                type="success"
+                size="small"
+                icon="el-icon-refresh-right"
+                :loading="resending"
+                @click="handleConfirm"
+            >
+                {{ $t('Resend') }}
+            </el-button>
+        </span>
+    </el-dialog>
+</template>
+
+<script>
+export default {
+    name: 'ResendDialog',
+    props: {
+        value: {
+            type: Boolean,
+            default: false
+        },
+        log: {
+            type: Object,
+            default: null
+        },
+        resending: {
+            type: Boolean,
+            default: false
+        }
+    },
+    data() {
+        return {
+            form: {
+                target: 'original',
+                customEmail: ''
+            }
+        };
+    },
+    computed: {
+        visible: {
+            get() {
+                return this.value;
+            },
+            set(val) {
+                this.$emit('input', val);
+            }
+        }
+    },
+    watch: {
+        value(newVal) {
+            if (newVal) {
+                this.form.target = 'original';
+                this.form.customEmail = '';
+            }
+        },
+        'form.target'(newVal) {
+            if (newVal === 'custom') {
+                this.$nextTick(() => {
+                    if (this.$refs.customInput) {
+                        this.$refs.customInput.focus();
+                    }
+                });
+            }
+        }
+    },
+    methods: {
+        handleClosed() {
+            this.$emit('closed');
+        },
+        handleConfirm() {
+            if (this.resending) {
+                return;
+            }
+
+            const payload = { target: this.form.target };
+
+            if (this.form.target === 'self') {
+                const userEmail = this.appVars && this.appVars.user_email
+                    ? this.appVars.user_email.trim()
+                    : '';
+
+                if (!userEmail) {
+                    this.$notify.error({
+                        offset: 19,
+                        title: this.$t('Oops!'),
+                        message: this.$t('No account email is available for the current user.')
+                    });
+                    return;
+                }
+
+                payload.recipients = [userEmail];
+            }
+
+            if (this.form.target === 'custom') {
+                const parsed = this.parseEmails(this.form.customEmail);
+
+                if (!parsed.valid.length && !parsed.invalid.length) {
+                    this.$notify.error({
+                        offset: 19,
+                        title: this.$t('Oops!'),
+                        message: this.$t('Please enter a valid email address')
+                    });
+                    return;
+                }
+
+                if (parsed.invalid.length) {
+                    this.$notify.error({
+                        offset: 19,
+                        title: this.$t('Oops!'),
+                        message: this.$t('Please enter a valid email address') + ': ' + parsed.invalid.join(', ')
+                    });
+                    return;
+                }
+
+                payload.recipients = parsed.valid;
+            }
+
+            this.$emit('confirm', payload);
+        },
+        parseEmails(input) {
+            const tokens = (input || '')
+                .split(/[\s,;]+/)
+                .map(t => t.trim())
+                .filter(Boolean);
+
+            const valid = [];
+            const invalid = [];
+            const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+            tokens.forEach(token => {
+                if (re.test(token)) {
+                    valid.push(token);
+                } else {
+                    invalid.push(token);
+                }
+            });
+
+            return { valid, invalid };
+        },
+        formatOriginalRecipients(to) {
+            if (!to) {
+                return '<em>—</em>';
+            }
+            return to;
+        }
+    }
+};
+</script>


### PR DESCRIPTION
## Summary

Currently, clicking **Resend** next to a logged email in **Settings → Fluent SMTP → Email Logs** sends a copy to the original recipient(s) immediately. This PR replaces that one-click action with a small dialog that lets the user pick where the resend should actually go:

1. **Original recipient(s)** — current behavior, default option.
2. **My account email** — the email of the currently logged-in WordPress user (uses `appVars.user_email`).
3. **A different email address** — a free-text field that accepts one or more comma-separated addresses.

This is useful when, for example, an admin wants to forward a customer order email to themselves or a teammate to inspect what the customer received, without having to dig into the database, the mail provider's UI, or the original inbox.

The Retry action on **failed** emails is intentionally left unchanged — it still retries to the original recipient as before.

## Why

Resending an already-sent email almost always means "I want to look at this myself" rather than "I want to spam the customer again." With the existing one-click behavior, the only way to inspect a sent email's rendered output is to ask the original recipient to forward it back. The new dialog makes the common case (resend to me) trivial while preserving the original behavior as the default.

## What changed

### Backend

- **`app/Models/Logger.php`** — `resendEmailFromLog()` now accepts an optional `$recipients` array. When provided:
  - The `To` is replaced with the validated addresses.
  - `cc` and `bcc` headers are stripped so the email isn't accidentally also sent to the original copy/blind copy recipients.
  - `From`, subject, body, attachments, and all other headers are preserved exactly.
  - The original log row's `to` field is **not** modified — only `status`, `updated_at`, and `resent_count` change, matching the existing behavior. The log remains an accurate audit record of the original send.
- **`app/Http/Controllers/LoggerController.php`** — `retry()` reads an optional `recipients` field from the AJAX request, runs it through a new `sanitizeRecipients()` helper that uses `sanitize_email()` + `is_email()`, supports comma/semicolon/whitespace-separated lists, and returns a 422 with a translated message on bad input. The success notice includes the actual destination(s).

### Frontend

- **`resources/admin/Modules/Logger/ResendDialog.vue`** (new) — Element-UI dialog with an `el-radio-group` for the three options. Custom-email mode reveals an `el-input` that auto-focuses, supports comma-separated values, and validates client-side before sending.
- **`resources/admin/Modules/Logger/Logs.vue`** — the row-level Resend button now opens the dialog instead of firing the request directly. `handleRetry()` was generalized to accept an optional `recipients` array.
- **`resources/admin/Modules/Logger/LogViewer.vue`** — same change for the Resend button inside the log viewer modal.

## Compatibility / safety

- **Fully backwards compatible.** The existing `/logs/retry` endpoint still works without the new `recipients` parameter — the dialog defaults to "Original recipient(s)" which sends an empty parameter and produces the exact same behavior as today.
- **No DB schema changes.**
- **No new dependencies.** Uses only Element UI components already registered in `resources/admin/Bits/FluentMail.js`.
- **Strings go through `$t()` / `__()`** so they'll be picked up the next time `translation.node.js` regenerates `app/Services/TransStrings.php`.
- **Bulk Resend (`/logs/retry-bulk`) is untouched** — it still resends to the original recipients, which is the only sensible default for bulk operations.

## Test plan

- [ ] Enable email logging and send a test email.
- [ ] Click **Resend** on the row → dialog opens; "Original recipient(s)" is selected by default.
- [ ] Click **Resend** in the dialog → email goes to the original recipient (unchanged behavior).
- [ ] Pick **My account email** → email goes to the logged-in user.
- [ ] Pick **A different email address**, enter one address → email goes only to that address.
- [ ] Same, but enter `me@example.com, friend@example.com` → both addresses receive the email.
- [ ] Enter an invalid address → client-side error, no request sent. Bypass client validation (e.g. via curl) → server returns 422 with a translated error.
- [ ] Resend from the **log viewer** dialog (the eye icon) — same dialog, same behavior.
- [ ] Confirm the original log row's `to` column is unchanged after a custom-recipient resend; only `resent_count` and `updated_at` advance.
- [ ] Confirm `cc` / `bcc` headers in the resent email are stripped when a custom recipient is used (and preserved when sending to the original recipient).
- [ ] Bulk resend still works as before.
- [ ] Retry on a failed email still works as before (no dialog).

## Screenshot

<img width="518" height="509" alt="2026-05-26 20_31_40-Abundant Designs - KeePassXC" src="https://github.com/user-attachments/assets/78642add-7de5-4cef-98e5-404f110868a7" />
