### PR TITLE
Support multiple SMTP configs via wp-config.php and migrate connection IDs (resolves #400)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ vendor
 fluent-smtp/*
 research
 .claude
+*.code-workspace

--- a/app/Functions/helpers.php
+++ b/app/Functions/helpers.php
@@ -87,13 +87,25 @@ if (!function_exists('fluentMailDefaultConnection')) {
             return [];
         }
 
-        if (
-            isset($settings['misc']['default_connection']) &&
-            isset($settings['connections'][$settings['misc']['default_connection']])
-        ) {
-            $default = $settings['misc']['default_connection'];
-            $defaultConnection = $settings['connections'][$default]['provider_settings'];
-        } else if (count($settings['connections'])) {
+        $defaultIntId = \FluentMail\Includes\Support\Arr::get($settings, 'misc.default_connection');
+
+        if (!is_null($defaultIntId) && $defaultIntId !== '') {
+            // Find connection by integer ID
+            foreach ($settings['connections'] as $connection) {
+                $connId = \FluentMail\Includes\Support\Arr::get($connection, 'provider_settings.connection_id');
+                if (!is_null($connId) && (int)$connId === (int)$defaultIntId) {
+                    $defaultConnection = $connection['provider_settings'];
+                    return $defaultConnection;
+                }
+            }
+            // Fallback to legacy MD5 lookup if not found as an integer ID
+            if (isset($settings['connections'][$defaultIntId])) {
+                $defaultConnection = $settings['connections'][$defaultIntId]['provider_settings'];
+                return $defaultConnection;
+            }
+        }
+
+        if (count($settings['connections'])) {
             $connection = reset($settings['connections']);
             $defaultConnection = $connection['provider_settings'];
         } else {
@@ -711,6 +723,67 @@ if (!function_exists('fluentMailGetSettings')) {
             }
         }
 
+        if (!empty($settings['connections']) && is_array($settings['connections'])) {
+            foreach ($settings['connections'] as $key => $connection) {
+                $ps = $connection['provider_settings'];
+
+                if (\FluentMail\Includes\Support\Arr::get($ps, 'key_store') !== 'wp_config') {
+                    continue;
+                }
+
+                $serial = \FluentMail\Includes\Support\Arr::get($ps, 'connection_id');
+                if (is_null($serial)) {
+                    // Legacy single-constant fallback
+                    $username = defined('FLUENTMAIL_SMTP_USERNAME') ? FLUENTMAIL_SMTP_USERNAME : '';
+                    $password = defined('FLUENTMAIL_SMTP_PASSWORD') ? FLUENTMAIL_SMTP_PASSWORD : '';
+
+                    if ($username) {
+                        $settings['connections'][$key]['provider_settings']['username'] = $username;
+                    }
+                    if ($password) {
+                        $settings['connections'][$key]['provider_settings']['password'] = $password;
+                    }
+                    continue;
+                }
+
+                $suffix = '_' . $serial;
+
+                // Resolve all SMTP settings from constants (if defined) or fall back to default/empty values.
+                $host = defined('FLUENTMAIL_SMTP_HOST' . $suffix) ? constant('FLUENTMAIL_SMTP_HOST' . $suffix) : '';
+                $port = defined('FLUENTMAIL_SMTP_PORT' . $suffix) ? (int)constant('FLUENTMAIL_SMTP_PORT' . $suffix) : 587;
+                $enc  = defined('FLUENTMAIL_SMTP_ENCRYPTION' . $suffix) ? constant('FLUENTMAIL_SMTP_ENCRYPTION' . $suffix) : 'tls';
+                $auth = defined('FLUENTMAIL_SMTP_AUTH' . $suffix) ? constant('FLUENTMAIL_SMTP_AUTH' . $suffix) : 'yes';
+                $username = defined('FLUENTMAIL_SMTP_USERNAME' . $suffix) ? constant('FLUENTMAIL_SMTP_USERNAME' . $suffix) : '';
+                $password = defined('FLUENTMAIL_SMTP_PASSWORD' . $suffix) ? constant('FLUENTMAIL_SMTP_PASSWORD' . $suffix) : '';
+                $senderName = defined('FLUENTMAIL_SMTP_SENDER_NAME' . $suffix) ? constant('FLUENTMAIL_SMTP_SENDER_NAME' . $suffix) : get_bloginfo('name');
+
+                // Sender email: auto-derive from username if it is a valid email, else read explicit constant.
+                $senderEmail = '';
+                if (is_email($username)) {
+                    $senderEmail = $username;
+                } else {
+                    $senderEmail = defined('FLUENTMAIL_SMTP_SENDER_EMAIL' . $suffix) ? constant('FLUENTMAIL_SMTP_SENDER_EMAIL' . $suffix) : '';
+                }
+
+                // Merge resolved values into the connection settings
+                $settings['connections'][$key]['provider_settings'] = array_merge($ps, [
+                    'host'         => $host,
+                    'port'         => $port,
+                    'encryption'   => $enc,
+                    'auth'         => $auth,
+                    'username'     => $username,
+                    'password'     => $password,
+                    'sender_email' => $senderEmail,
+                    'sender_name'  => $senderName,
+                ]);
+
+                // Ensure mappings reflect the resolved sender_email
+                if ($senderEmail) {
+                    $settings['mappings'][$senderEmail] = $key;
+                }
+            }
+        }
+
         $cachedSettings = $settings;
 
         return $settings;
@@ -727,6 +800,20 @@ if (!function_exists('fluentMailSetSettings')) {
      */
     function fluentMailSetSettings($settings)
     {
+        if (!empty($settings['connections']) && is_array($settings['connections'])) {
+            foreach ($settings['connections'] as $key => $connection) {
+                $ps = \FluentMail\Includes\Support\Arr::get($connection, 'provider_settings');
+                if ($ps && \FluentMail\Includes\Support\Arr::get($ps, 'key_store') === 'wp_config') {
+                    $serial = \FluentMail\Includes\Support\Arr::get($ps, 'connection_id');
+                    if (!is_null($serial)) {
+                        $fieldsToStrip = ['host', 'port', 'encryption', 'auth', 'username', 'password', 'sender_email', 'sender_name'];
+                        foreach ($fieldsToStrip as $field) {
+                            unset($settings['connections'][$key]['provider_settings'][$field]);
+                        }
+                    }
+                }
+            }
+        }
 
         /**
          * Get the value of the 'use_encrypt' setting.

--- a/app/Hooks/Handlers/ActionsRegistrar.php
+++ b/app/Hooks/Handlers/ActionsRegistrar.php
@@ -52,6 +52,7 @@ class ActionsRegistrar
         $this->registerSiteInitialization();
         $this->registerCustomActions();
         $this->registerRestRoutes();
+        $this->registerMigration();
     }
 
     /**
@@ -112,6 +113,21 @@ class ActionsRegistrar
                 'callback'            => [$this, 'handleOutlookCallback'],
                 'permission_callback' => [$this, 'verifyOutlookCallbackState'],
             ]);
+        });
+    }
+
+    /**
+     * Register connection ID migration hook on admin_init.
+     *
+     * @return void
+     */
+    protected function registerMigration()
+    {
+        $this->app->addAction('admin_init', function () {
+            if (!get_option('_fluentsmtp_conn_id_migrated')) {
+                (new \FluentMail\App\Models\Settings())->assignConnectionIds();
+                update_option('_fluentsmtp_conn_id_migrated', '1', false);
+            }
         });
     }
 

--- a/app/Hooks/Handlers/SchedulerHandler.php
+++ b/app/Hooks/Handlers/SchedulerHandler.php
@@ -172,12 +172,20 @@ class SchedulerHandler
 
         $fallbackConnectionId = \FluentMail\Includes\Support\Arr::get($settings, 'misc.fallback_connection');
 
-        if (!$fallbackConnectionId) {
+        if (is_null($fallbackConnectionId) || $fallbackConnectionId === '') {
             do_action('fluentmail_email_sending_failed_no_fallback', $logId, $handler, $data);
             return false;
         }
 
-        $fallbackConnection = \FluentMail\Includes\Support\Arr::get($settings, 'connections.' . $fallbackConnectionId);
+        // Try lookup by integer ID
+        $fallbackConnection = null;
+        $settingsModel = new \FluentMail\App\Models\Settings();
+        [$fallbackKey, $fallbackConnection] = $settingsModel->getConnectionByIntId($fallbackConnectionId);
+
+        // Fallback to legacy MD5 key lookup if not found
+        if (!$fallbackConnection) {
+            $fallbackConnection = \FluentMail\Includes\Support\Arr::get($settings, 'connections.' . $fallbackConnectionId);
+        }
 
         if (!$fallbackConnection) {
             do_action('fluentmail_email_sending_failed_no_fallback', $logId, $handler, $data);

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -19,6 +19,10 @@ class SettingsController extends Controller
         try {
             $setting = $settings->get();
 
+            if (isset($setting['connections'])) {
+                $setting['connections'] = $this->maskConnections($setting['connections']);
+            }
+
             return $this->sendSuccess([
                 'settings' => $setting
             ]);
@@ -92,7 +96,7 @@ class SettingsController extends Controller
 
             return $this->sendSuccess([
                 'message'     => __('Settings saved successfully.', 'fluent-smtp'),
-                'connections' => $settings->getConnections(),
+                'connections' => $this->maskConnections($settings->getConnections()),
                 'mappings'    => $settings->getMappings(),
                 'misc'        => $settings->getMisc()
             ]);
@@ -120,9 +124,38 @@ class SettingsController extends Controller
     {
         $this->verify();
 
-        $settings = $settings->delete($request->get('key'));
+        $connectionId = $request->get('connection_id');
+        if (!is_null($connectionId) && $connectionId !== '') {
+            [$key, $connection] = $settings->getConnectionByIntId((int)$connectionId);
+            if ($key) {
+                $settingsData = $settings->delete($key);
+                if (isset($settingsData['connections'])) {
+                    $settingsData['connections'] = $this->maskConnections($settingsData['connections']);
+                }
+                return $this->sendSuccess($settingsData);
+            }
+        }
 
-        return $this->sendSuccess($settings);
+        $settingsData = $settings->delete($request->get('key'));
+        if (isset($settingsData['connections'])) {
+            $settingsData['connections'] = $this->maskConnections($settingsData['connections']);
+        }
+
+        return $this->sendSuccess($settingsData);
+    }
+
+    protected function maskConnections($connections)
+    {
+        if (is_array($connections)) {
+            foreach ($connections as $key => $connection) {
+                if (Arr::get($connection, 'provider_settings.key_store') === 'wp_config') {
+                    if (isset($connection['provider_settings']['password'])) {
+                        $connections[$key]['provider_settings']['password'] = '********************';
+                    }
+                }
+            }
+        }
+        return $connections;
     }
 
     public function storeGlobals(Request $request, Settings $settings)

--- a/app/Models/Settings.php
+++ b/app/Models/Settings.php
@@ -22,6 +22,84 @@ class Settings
         return $this->get();
     }
 
+    public function getNextConnectionId()
+    {
+        $settings = $this->getSettings();
+        $connections = $this->getConnections($settings);
+        $maxId = -1;
+        foreach ($connections as $connection) {
+            $connId = Arr::get($connection, 'provider_settings.connection_id');
+            if (!is_null($connId)) {
+                $maxId = max($maxId, (int)$connId);
+            }
+        }
+        return $maxId + 1;
+    }
+
+    public function getConnectionByIntId($id)
+    {
+        $settings = $this->getSettings();
+        $connections = $this->getConnections($settings);
+        foreach ($connections as $key => $connection) {
+            $connId = Arr::get($connection, 'provider_settings.connection_id');
+            if (!is_null($connId) && (int)$connId === (int)$id) {
+                return [$key, $connection];
+            }
+        }
+        return [null, null];
+    }
+
+    public function assignConnectionIds()
+    {
+        $settings = $this->getSettings();
+        if (empty($settings['connections'])) {
+            return;
+        }
+
+        $modified = false;
+
+        $maxId = -1;
+        foreach ($settings['connections'] as $connection) {
+            $connId = Arr::get($connection, 'provider_settings.connection_id');
+            if (!is_null($connId)) {
+                $maxId = max($maxId, (int)$connId);
+            }
+        }
+
+        $nextId = $maxId + 1;
+
+        foreach ($settings['connections'] as $key => $connection) {
+            $connId = Arr::get($connection, 'provider_settings.connection_id');
+            if (is_null($connId)) {
+                $settings['connections'][$key]['provider_settings']['connection_id'] = $nextId;
+                $nextId++;
+                $modified = true;
+            }
+        }
+
+        $defaultMd5 = Arr::get($settings, 'misc.default_connection');
+        if ($defaultMd5 && isset($settings['connections'][$defaultMd5])) {
+            $intId = Arr::get($settings['connections'][$defaultMd5], 'provider_settings.connection_id');
+            if (!is_null($intId)) {
+                $settings['misc']['default_connection'] = (int)$intId;
+                $modified = true;
+            }
+        }
+
+        $fallbackMd5 = Arr::get($settings, 'misc.fallback_connection');
+        if ($fallbackMd5 && isset($settings['connections'][$fallbackMd5])) {
+            $intId = Arr::get($settings['connections'][$fallbackMd5], 'provider_settings.connection_id');
+            if (!is_null($intId)) {
+                $settings['misc']['fallback_connection'] = (int)$intId;
+                $modified = true;
+            }
+        }
+
+        if ($modified) {
+            fluentMailSetSettings($settings);
+        }
+    }
+
     public function store($inputs)
     {
         $settings = $this->getSettings();
@@ -31,12 +109,20 @@ class Settings
 
         $key = $inputs['connection_key'];
 
+        $existingConnectionId = null;
         if (isset($connections[$key])) {
+            $existingConnectionId = Arr::get($connections[$key], 'provider_settings.connection_id');
             $mappings = array_filter($mappings, function ($mappingKey) use ($key) {
                 return $mappingKey != $key;
             });
             unset($connections[$key]);
         }
+
+        if (is_null($existingConnectionId)) {
+            $existingConnectionId = $this->getNextConnectionId();
+        }
+
+        $inputs['connection']['connection_id'] = $existingConnectionId;
 
         $primaryEmails = [];
         foreach ($connections as $connection) {
@@ -91,8 +177,20 @@ class Settings
             ];
         }
 
-        if (empty($misc['default_connection']) || $misc['default_connection'] == $key) {
-            $misc['default_connection'] = $uniqueKey;
+        $defaultConnectionId = Arr::get($misc, 'default_connection');
+        $isDefaultMatched = false;
+        if (empty($defaultConnectionId)) {
+            $isDefaultMatched = true;
+        } else {
+            if (!is_null($existingConnectionId) && (string)$defaultConnectionId === (string)$existingConnectionId) {
+                $isDefaultMatched = true;
+            } elseif ((string)$defaultConnectionId === (string)$key) {
+                $isDefaultMatched = true;
+            }
+        }
+
+        if ($isDefaultMatched) {
+            $misc['default_connection'] = $existingConnectionId;
             $settings['misc'] = $misc;
         }
 
@@ -115,9 +213,11 @@ class Settings
     {
         $settings = $this->getSettings();
 
-
         $mappings = $settings['mappings'];
         $connections = $settings['connections'];
+
+        $deletedConnection = isset($connections[$key]) ? $connections[$key] : null;
+        $deletedIntId = $deletedConnection ? Arr::get($deletedConnection, 'provider_settings.connection_id') : null;
 
         unset($connections[$key]);
 
@@ -130,13 +230,37 @@ class Settings
         $settings['mappings'] = $mappings;
         $settings['connections'] = $connections;
 
-        if (Arr::get($settings, 'misc.default_connection') == $key) {
-            $default = Arr::get($settings, 'mappings', []);
-            $default = reset($default);
-            Arr::set($settings, 'misc.default_connection', $default ?: '');
+        $defaultConnectionId = Arr::get($settings, 'misc.default_connection');
+        $isDefaultMatched = false;
+        if (!is_null($defaultConnectionId) && $defaultConnectionId !== '') {
+            if (!is_null($deletedIntId) && (string)$defaultConnectionId === (string)$deletedIntId) {
+                $isDefaultMatched = true;
+            } elseif ((string)$defaultConnectionId === (string)$key) {
+                $isDefaultMatched = true;
+            }
         }
 
-        if (Arr::get($settings, 'misc.fallback_connection') == $key) {
+        if ($isDefaultMatched) {
+            if (count($connections)) {
+                $firstConn = reset($connections);
+                $newDefaultId = Arr::get($firstConn, 'provider_settings.connection_id');
+                Arr::set($settings, 'misc.default_connection', !is_null($newDefaultId) ? (int)$newDefaultId : '');
+            } else {
+                Arr::set($settings, 'misc.default_connection', '');
+            }
+        }
+
+        $fallbackConnectionId = Arr::get($settings, 'misc.fallback_connection');
+        $isFallbackMatched = false;
+        if (!is_null($fallbackConnectionId) && $fallbackConnectionId !== '') {
+            if (!is_null($deletedIntId) && (string)$fallbackConnectionId === (string)$deletedIntId) {
+                $isFallbackMatched = true;
+            } elseif ((string)$fallbackConnectionId === (string)$key) {
+                $isFallbackMatched = true;
+            }
+        }
+
+        if ($isFallbackMatched) {
             Arr::set($settings, 'misc.fallback_connection', '');
         }
 

--- a/app/Services/Mailer/Providers/Smtp/Handler.php
+++ b/app/Services/Mailer/Providers/Smtp/Handler.php
@@ -129,7 +129,7 @@ class Handler extends BaseHandler
 
     public function setSettings($settings)
     {
-        if (Arr::get($settings, 'key_store') == 'wp_config') {
+        if (Arr::get($settings, 'key_store') == 'wp_config' && is_null(Arr::get($settings, 'connection_id'))) {
             $settings['username'] = defined('FLUENTMAIL_SMTP_USERNAME') ? FLUENTMAIL_SMTP_USERNAME : '';
             $settings['password'] = defined('FLUENTMAIL_SMTP_PASSWORD') ? FLUENTMAIL_SMTP_PASSWORD : '';
         }

--- a/app/Services/Mailer/Providers/Smtp/ValidatorTrait.php
+++ b/app/Services/Mailer/Providers/Smtp/ValidatorTrait.php
@@ -14,31 +14,61 @@ trait ValidatorTrait
         $errors = [];
 
         $keyStoreType = Arr::get($connection, 'key_store', 'db');
+        $serial = Arr::get($connection, 'connection_id');
 
-        if (!Arr::get($connection, 'host')) {
-            $errors['host']['required'] = __('SMTP host is required.', 'fluent-smtp');
-        }
+        if ($keyStoreType == 'wp_config' && !is_null($serial)) {
+            $suffix = '_' . $serial;
 
-        if (!Arr::get($connection, 'port')) {
-            $errors['port']['required'] = __('SMTP port is required.', 'fluent-smtp');
-        }
+            $hostConst     = 'FLUENTMAIL_SMTP_HOST' . $suffix;
+            $usernameConst = 'FLUENTMAIL_SMTP_USERNAME' . $suffix;
+            $passwordConst = 'FLUENTMAIL_SMTP_PASSWORD' . $suffix;
 
-        if (Arr::get($connection, 'auth') == 'yes') {
-            if ($keyStoreType == 'wp_config') {
-                if (!defined('FLUENTMAIL_SMTP_USERNAME') || !FLUENTMAIL_SMTP_USERNAME) {
-                    $errors['username']['required'] = __('Please define FLUENTMAIL_SMTP_USERNAME in wp-config.php file.', 'fluent-smtp');
+            if (!defined($hostConst) || !constant($hostConst)) {
+                $errors['host']['required'] = sprintf(__('Please define %s in wp-config.php.', 'fluent-smtp'), $hostConst);
+            }
+            if (!defined($usernameConst) || !constant($usernameConst)) {
+                $errors['username']['required'] = sprintf(__('Please define %s in wp-config.php.', 'fluent-smtp'), $usernameConst);
+            }
+            if (!defined($passwordConst) || !constant($passwordConst)) {
+                $errors['password']['required'] = sprintf(__('Please define %s in wp-config.php.', 'fluent-smtp'), $passwordConst);
+            }
+
+            // Validate sender_email if username is not a valid email
+            if (defined($usernameConst) && !is_email(constant($usernameConst))) {
+                $senderConst = 'FLUENTMAIL_SMTP_SENDER_EMAIL' . $suffix;
+                if (!defined($senderConst) || !is_email(constant($senderConst))) {
+                    $errors['sender_email']['required'] = sprintf(
+                        __('Username is not an email. Please define %s in wp-config.php.', 'fluent-smtp'),
+                        $senderConst
+                    );
                 }
+            }
+        } else {
+            if (!Arr::get($connection, 'host')) {
+                $errors['host']['required'] = __('SMTP host is required.', 'fluent-smtp');
+            }
 
-                if (!defined('FLUENTMAIL_SMTP_PASSWORD') || !FLUENTMAIL_SMTP_PASSWORD) {
-                    $errors['password']['required'] = __('Please define FLUENTMAIL_SMTP_PASSWORD in wp-config.php file.', 'fluent-smtp');
-                }
-            } else {
-                if (!Arr::get($connection, 'username')) {
-                    $errors['username']['required'] = __('SMTP username is required.', 'fluent-smtp');
-                }
+            if (!Arr::get($connection, 'port')) {
+                $errors['port']['required'] = __('SMTP port is required.', 'fluent-smtp');
+            }
 
-                if (!Arr::get($connection, 'password')) {
-                    $errors['password']['required'] = __('SMTP password is required.', 'fluent-smtp');
+            if (Arr::get($connection, 'auth') == 'yes') {
+                if ($keyStoreType == 'wp_config') {
+                    if (!defined('FLUENTMAIL_SMTP_USERNAME') || !FLUENTMAIL_SMTP_USERNAME) {
+                        $errors['username']['required'] = __('Please define FLUENTMAIL_SMTP_USERNAME in wp-config.php file.', 'fluent-smtp');
+                    }
+
+                    if (!defined('FLUENTMAIL_SMTP_PASSWORD') || !FLUENTMAIL_SMTP_PASSWORD) {
+                        $errors['password']['required'] = __('Please define FLUENTMAIL_SMTP_PASSWORD in wp-config.php file.', 'fluent-smtp');
+                    }
+                } else {
+                    if (!Arr::get($connection, 'username')) {
+                        $errors['username']['required'] = __('SMTP username is required.', 'fluent-smtp');
+                    }
+
+                    if (!Arr::get($connection, 'password')) {
+                        $errors['password']['required'] = __('SMTP password is required.', 'fluent-smtp');
+                    }
                 }
             }
         }

--- a/resources/admin/Modules/Settings/Connection.vue
+++ b/resources/admin/Modules/Settings/Connection.vue
@@ -36,7 +36,19 @@
         },
         created() {
             const key = this.$route.query.connection_key;
-            if (key && key !== '0') {
+            const id = this.$route.query.connection_id;
+
+            if (id !== undefined && id !== null && id !== '') {
+                this.title = this.$t('Edit Connection');
+                jQuery.each(this.settings.connections, (connKey, connection) => {
+                    const connId = connection.provider_settings.connection_id;
+                    if (connId !== undefined && connId !== null && String(connId) === String(id)) {
+                        this.provider = connection.provider_settings;
+                        this.provider_key = connKey;
+                        return false;
+                    }
+                });
+            } else if (key && key !== '0') {
                 this.title = this.$t('Edit Connection');
                 this.provider = this.settings.connections[key].provider_settings;
                 this.provider_key = key;

--- a/resources/admin/Modules/Settings/ConnectionWizard.vue
+++ b/resources/admin/Modules/Settings/ConnectionWizard.vue
@@ -21,6 +21,7 @@
                                     data-1p-ignore
                                     data-form-type="other"
                                     name="fluentsmtp_sender_email"
+                                    :disabled="connection.key_store === 'wp_config'"
                                 ></el-input>
                                 <p style="color: red;" v-if="is_conflicted">{{ $t('__ANOTHER_CONNECTION_NOTICE') }}</p>
                             </el-form-item>
@@ -60,6 +61,7 @@
                                     type="text"
                                     :placeholder="$t('From Name')"
                                     v-model="connection.sender_name"
+                                    :disabled="connection.key_store === 'wp_config'"
                                 ></el-input>
                                 <error :error="errors.get('sender_name')"/>
                             </el-form-item>
@@ -86,6 +88,7 @@
                         :connection="connection"
                         :provider="providers[connection.provider]"
                         :is_new="is_new"
+                        :connections="connections"
                     />
                 </div>
                 <p v-if="providers[connection.provider].note" style="padding: 5px 0px; font-size: 16px; color: #ff5722;"

--- a/resources/admin/Modules/Settings/Connections.vue
+++ b/resources/admin/Modules/Settings/Connections.vue
@@ -34,6 +34,7 @@
                             <el-table-column prop="sender_email" :label="$t('From Email')">
                                 <template slot-scope="scope">
                                     <span style="cursor: pointer;" @click="showConnection(scope.row)">{{ scope.row.sender_email }}</span>
+                                    <el-tag size="mini" type="warning" style="margin-left: 8px" v-slot v-if="scope.row.key_store === 'wp_config'">wp-config</el-tag>
                                 </template>
                             </el-table-column>
                             <el-table-column width="120" :label="$t('Actions')" align="center">
@@ -133,15 +134,26 @@
                 this.$router.push({ name: 'connection' });
             },
             editConnection(connection) {
-                this.$router.push({
-                    name: 'connection',
-                    query: { connection_key: connection.unique_key }
-                });
+                if (connection.connection_id !== undefined && connection.connection_id !== null) {
+                    this.$router.push({
+                        name: 'connection',
+                        query: { connection_id: connection.connection_id }
+                    });
+                } else {
+                    this.$router.push({
+                        name: 'connection',
+                        query: { connection_key: connection.unique_key }
+                    });
+                }
             },
             async deleteConnection(connection) {
-                const result = await this.$post('settings/delete', {
-                    key: connection.unique_key
-                });
+                const postData = {};
+                if (connection.connection_id !== undefined && connection.connection_id !== null) {
+                    postData.connection_id = connection.connection_id;
+                } else {
+                    postData.key = connection.unique_key;
+                }
+                const result = await this.$post('settings/delete', postData);
 
                 this.settings.connections = result.data.connections;
                 this.settings.misc.default_connection = result.data.misc.default_connection;

--- a/resources/admin/Modules/Settings/Partials/Providers/Smtp.vue
+++ b/resources/admin/Modules/Settings/Partials/Providers/Smtp.vue
@@ -1,152 +1,233 @@
 <template>
     <div>
-        <el-row :gutter="20">
-            <el-col :md="12" :sm="24">
-                <el-form-item>
-                    <label for="host">
-                        {{ $t('SMTP Host') }}
-                    </label>
-                    <el-input :placeholder="$t('SMTP Host')" id="host" v-model="connection.host"/>
-                    <error :error="errors.get('host')"/>
-                </el-form-item>
-            </el-col>
-            <el-col :md="12" :sm="24">
-                <el-form-item>
-                    <label for="port">
-                        {{ $t('SMTP Port') }}
-                    </label>
-
-                    <el-input :placeholder="$t('SMTP Port')" id="port" v-model="connection.port"/>
-                    <error :error="errors.get('port')"/>
-                </el-form-item>
-            </el-col>
-        </el-row>
-
-        <el-row :gutter="20">
-            <el-col :span="24">
-                <el-form-item style="margin: 20px 0">
-                    <label>
-                        {{ $t('Encryption') }}
-                    </label>
-
-                    <div class="small-help-text" style="display:inline-block;">
-                        Select <strong>ssl</strong> on port <strong>465</strong>, or <strong>tls</strong> on port <strong>25</strong> or <strong>587</strong>
-                    </div>
-
-                    <div style="display:inline-block;margin-left: 20px;">
-                        <el-radio v-model="connection.encryption" label="none">{{ $t('None') }}</el-radio>
-                        <el-radio v-model="connection.encryption" label="ssl">{{ $t('SSL') }}</el-radio>
-                        <el-radio v-model="connection.encryption" label="tls">{{ $t('TLS') }}</el-radio>
-                    </div>
-                </el-form-item>
-            </el-col>
-        </el-row>
-
-        <el-row :gutter="20">
-            <el-col :span="24">
-                <el-form-item>
-                    <label for="auth">
-                        {{ $t('Use Auto TLS') }}
-                    </label>
-
-                    <el-switch
-                        v-model="connection.auto_tls"
-                        active-value="yes"
-                        inactive-value="no">
-                    </el-switch>
-
-                    <span class="small-help-text">
-                        {{ $t('__TLS_HELP') }}
-                    </span>
-                </el-form-item>
-            </el-col>
-        </el-row>
-
-        <el-row :gutter="20">
-            <el-col :span="24">
-                <el-form-item>
-                    <label for="auth">
-                        {{ $t('Authentication') }}
-                    </label>
-
-                    <el-switch
-                        v-model="connection.auth"
-                        active-value="yes"
-                        inactive-value="no">
-                    </el-switch>
-
-                    <span class="small-help-text">
-                        {{ $t('__SMTP_CRED_HELP') }}
-                    </span>
-                </el-form-item>
-            </el-col>
-        </el-row>
-
-        <template v-if="connection.auth == 'yes'">
+        <div style="margin-bottom: 20px;">
             <el-radio-group size="mini" v-model="connection.key_store">
-                <el-radio-button value="db" label="db">{{ $t('Store Access Keys in DB') }}</el-radio-button>
-                <el-radio-button value="wp_config" label="wp_config">{{ $t('Access Keys in Config File') }}</el-radio-button>
+                <el-radio-button value="db" label="db">{{ $t('Store Settings in DB') }}</el-radio-button>
+                <el-radio-button value="wp_config" label="wp_config">{{ $t('Settings in Config File') }}</el-radio-button>
             </el-radio-group>
+        </div>
 
-            <el-row :gutter="20" v-if="connection.key_store == 'db'" :class="{ disabled: connection.auth==='no' }">
-                <el-col :span="12">
+        <template v-if="connection.key_store == 'wp_config'">
+            <div class="fss_condesnippet_wrapper">
+                <el-form-item>
+                    <label style="font-weight: 600; font-size: 14px; margin-bottom: 8px; display: block;">
+                        {{ $t('Copy & paste the following snippet into your wp-config.php file:') }}
+                    </label>
+                    <div class="code_snippet_container" style="background: #1e1e1e; border-radius: 8px; padding: 16px; margin-bottom: 20px; font-family: monospace; color: #abb2bf;">
+                        <textarea readonly style="width: 100%; height: 180px; background: transparent; border: none; color: #5cb85c; font-family: 'Courier New', Courier, monospace; font-size: 13px; outline: none; resize: none; line-height: 1.5;" @focus="$event.target.select()">// Required settings
+define( 'FLUENTMAIL_SMTP_HOST_{{ connectionId }}', '{{ connection.host || "mail.example.com" }}' );
+define( 'FLUENTMAIL_SMTP_USERNAME_{{ connectionId }}', '{{ connection.username || "user@example.com" }}' );
+define( 'FLUENTMAIL_SMTP_PASSWORD_{{ connectionId }}', '{{ connection.password || "your-smtp-password" }}' );
+
+// Optional settings (defaults shown)
+define( 'FLUENTMAIL_SMTP_PORT_{{ connectionId }}', {{ connection.port || 587 }} );
+define( 'FLUENTMAIL_SMTP_ENCRYPTION_{{ connectionId }}', '{{ connection.encryption || "tls" }}' );
+define( 'FLUENTMAIL_SMTP_AUTH_{{ connectionId }}', '{{ connection.auth || "yes" }}' );
+define( 'FLUENTMAIL_SMTP_SENDER_NAME_{{ connectionId }}', '{{ connection.sender_name || "My Site" }}' );
+
+// Required only if username is not an email
+define( 'FLUENTMAIL_SMTP_SENDER_EMAIL_{{ connectionId }}', '{{ connection.sender_email || "sender@example.com" }}' );</textarea>
+                    </div>
+
+                    <!-- Live Status Panel -->
+                    <div class="live_status_panel" style="background: #f7f9fa; border: 1px solid #e1e4e6; border-radius: 8px; padding: 16px; margin-bottom: 15px;">
+                        <h4 style="margin: 0 0 12px 0; font-size: 14px; color: #2c3e50;">{{ $t('Live Status (Resolved from wp-config.php)') }}</h4>
+                        <table style="width: 100%; border-collapse: collapse; font-size: 13px; color: #555;">
+                            <tbody>
+                                <tr style="border-bottom: 1px solid #eaecef; height: 32px;">
+                                    <td style="font-weight: 600; width: 40%;">Host</td>
+                                    <td>
+                                        <el-tag size="mini" :type="connection.host ? 'success' : 'danger'">
+                                            {{ connection.host ? connection.host : 'Missing (Required)' }}
+                                        </el-tag>
+                                    </td>
+                                </tr>
+                                <tr style="border-bottom: 1px solid #eaecef; height: 32px;">
+                                    <td style="font-weight: 600;">Port</td>
+                                    <td>
+                                        <el-tag size="mini" type="info">{{ connection.port || 587 }}</el-tag>
+                                    </td>
+                                </tr>
+                                <tr style="border-bottom: 1px solid #eaecef; height: 32px;">
+                                    <td style="font-weight: 600;">Encryption</td>
+                                    <td>
+                                        <el-tag size="mini" type="info">{{ connection.encryption || 'tls' }}</el-tag>
+                                    </td>
+                                </tr>
+                                <tr style="border-bottom: 1px solid #eaecef; height: 32px;">
+                                    <td style="font-weight: 600;">Username</td>
+                                    <td>
+                                        <el-tag size="mini" :type="connection.username ? 'success' : 'danger'">
+                                            {{ connection.username ? connection.username : 'Missing (Required)' }}
+                                        </el-tag>
+                                    </td>
+                                </tr>
+                                <tr style="border-bottom: 1px solid #eaecef; height: 32px;">
+                                    <td style="font-weight: 600;">Password</td>
+                                    <td>
+                                        <el-tag size="mini" :type="connection.password && connection.password !== '********************' ? 'success' : 'danger'">
+                                            {{ connection.password ? 'Configured' : 'Missing (Required)' }}
+                                        </el-tag>
+                                    </td>
+                                </tr>
+                                <tr style="border-bottom: 1px solid #eaecef; height: 32px;">
+                                    <td style="font-weight: 600;">Sender Name</td>
+                                    <td>
+                                        <span style="color: #666;">{{ connection.sender_name || 'My Site' }}</span>
+                                    </td>
+                                </tr>
+                                <tr style="height: 32px;">
+                                    <td style="font-weight: 600;">Sender Email</td>
+                                    <td>
+                                        <el-tag size="mini" :type="connection.sender_email ? 'success' : 'danger'">
+                                            {{ connection.sender_email ? connection.sender_email : 'Missing' }}
+                                        </el-tag>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <error :error="errors.get('host')"/>
+                    <error :error="errors.get('username')"/>
+                    <error :error="errors.get('password')"/>
+                    <error :error="errors.get('sender_email')"/>
+                </el-form-item>
+            </div>
+        </template>
+
+        <template v-else>
+            <el-row :gutter="20">
+                <el-col :md="12" :sm="24">
                     <el-form-item>
-                        <label for="username">
-                            {{ $t('SMTP Username') }}
+                        <label for="host">
+                            {{ $t('SMTP Host') }}
                         </label>
-
-                        <el-input type="text"
-                                  id="username"
-                                  :placeholder="$t('Your SMTP Username')"
-                                  v-model="connection.username"
-                                  :disabled="isDisabledUsername"
-                        />
-
-                        <error :error="errors.get('username')"/>
+                        <el-input :placeholder="$t('SMTP Host')" id="host" v-model="connection.host"/>
+                        <error :error="errors.get('host')"/>
                     </el-form-item>
                 </el-col>
-
-                <el-col :span="12">
+                <el-col :md="12" :sm="24">
                     <el-form-item>
-                        <label for="smtp-password">
-                            {{ $t('SMTP Password') }}
+                        <label for="port">
+                            {{ $t('SMTP Port') }}
                         </label>
 
-                        <InputPassword
-                            id="smtp-password"
-                            v-model="connection.password"
-                            :disabled="isDisabledPassword"
-                            :disable_help="connection.disable_encryption === 'yes'"
-                        />
-                        <error :error="errors.get('password')"/>
-                    </el-form-item>
-                </el-col>
-
-                <el-col :span="24">
-                    <el-form-item>
-                        <el-checkbox true-label="yes" false-label="no" v-model="connection.disable_encryption">
-                            {{ $t('Disable Encryption for SMTP Password (Not Recommended)') }}
-                        </el-checkbox>
-                        <p style="color: red; margin-top: 0;" v-if="connection.disable_encryption === 'yes'">
-                            {{
-                                $t('By disabling encryption, your API key will be stored in plain text in the database. This is not recommended for security reasons. Enable only if your security plugin rotate WP SALTS frequently.')
-                            }}
-                        </p>
+                        <el-input :placeholder="$t('SMTP Port')" id="port" v-model="connection.port"/>
+                        <error :error="errors.get('port')"/>
                     </el-form-item>
                 </el-col>
             </el-row>
 
-            <div class="fss_condesnippet_wrapper" v-else-if="connection.key_store == 'wp_config'">
-                <el-form-item>
-                    <label>{{ $t('__WP_CONFIG_INSTRUCTION') }}</label>
-                    <div class="code_snippet">
-                        <textarea readonly style="width: 100%;">define( 'FLUENTMAIL_SMTP_USERNAME', '********************' );
-define( 'FLUENTMAIL_SMTP_PASSWORD', '********************' );</textarea>
-                    </div>
-                    <error :error="errors.get('username')"/>
-                    <error :error="errors.get('password')"/>
-                </el-form-item>
-            </div>
+            <el-row :gutter="20">
+                <el-col :span="24">
+                    <el-form-item style="margin: 20px 0">
+                        <label>
+                            {{ $t('Encryption') }}
+                        </label>
+
+                        <div class="small-help-text" style="display:inline-block;">
+                            Select <strong>ssl</strong> on port <strong>465</strong>, or <strong>tls</strong> on port <strong>25</strong> or <strong>587</strong>
+                        </div>
+
+                        <div style="display:inline-block;margin-left: 20px;">
+                            <el-radio v-model="connection.encryption" label="none">{{ $t('None') }}</el-radio>
+                            <el-radio v-model="connection.encryption" label="ssl">{{ $t('SSL') }}</el-radio>
+                            <el-radio v-model="connection.encryption" label="tls">{{ $t('TLS') }}</el-radio>
+                        </div>
+                    </el-form-item>
+                </el-col>
+            </el-row>
+
+            <el-row :gutter="20">
+                <el-col :span="24">
+                    <el-form-item>
+                        <label for="auth">
+                            {{ $t('Use Auto TLS') }}
+                        </label>
+
+                        <el-switch
+                            v-model="connection.auto_tls"
+                            active-value="yes"
+                            inactive-value="no">
+                        </el-switch>
+
+                        <span class="small-help-text">
+                            {{ $t('__TLS_HELP') }}
+                        </span>
+                    </el-form-item>
+                </el-col>
+            </el-row>
+
+            <el-row :gutter="20">
+                <el-col :span="24">
+                    <el-form-item>
+                        <label for="auth">
+                            {{ $t('Authentication') }}
+                        </label>
+
+                        <el-switch
+                            v-model="connection.auth"
+                            active-value="yes"
+                            inactive-value="no">
+                        </el-switch>
+
+                        <span class="small-help-text">
+                            {{ $t('__SMTP_CRED_HELP') }}
+                        </span>
+                    </el-form-item>
+                </el-col>
+            </el-row>
+
+            <template v-if="connection.auth == 'yes'">
+                <el-row :gutter="20" :class="{ disabled: connection.auth==='no' }">
+                    <el-col :span="12">
+                        <el-form-item>
+                            <label for="username">
+                                {{ $t('SMTP Username') }}
+                            </label>
+
+                            <el-input type="text"
+                                      id="username"
+                                      :placeholder="$t('Your SMTP Username')"
+                                      v-model="connection.username"
+                                      :disabled="isDisabledUsername"
+                            />
+
+                            <error :error="errors.get('username')"/>
+                        </el-form-item>
+                    </el-col>
+
+                    <el-col :span="12">
+                        <el-form-item>
+                            <label for="smtp-password">
+                                {{ $t('SMTP Password') }}
+                            </label>
+
+                            <InputPassword
+                                id="smtp-password"
+                                v-model="connection.password"
+                                :disabled="isDisabledPassword"
+                                :disable_help="connection.disable_encryption === 'yes'"
+                            />
+                            <error :error="errors.get('password')"/>
+                        </el-form-item>
+                    </el-col>
+
+                    <el-col :span="24">
+                        <el-form-item>
+                            <el-checkbox true-label="yes" false-label="no" v-model="connection.disable_encryption">
+                                {{ $t('Disable Encryption for SMTP Password (Not Recommended)') }}
+                            </el-checkbox>
+                            <p style="color: red; margin-top: 0;" v-if="connection.disable_encryption === 'yes'">
+                                {{
+                                    $t('By disabling encryption, your API key will be stored in plain text in the database. This is not recommended for security reasons. Enable only if your security plugin rotate WP SALTS frequently.')
+                                }}
+                            </p>
+                        </el-form-item>
+                    </el-col>
+                </el-row>
+            </template>
         </template>
     </div>
 </template>
@@ -157,7 +238,7 @@ import Error from '@/Pieces/Error';
 
 export default {
     name: 'Smtp',
-    props: ['connection', 'errors'],
+    props: ['connection', 'errors', 'connections'],
     components: {
         InputPassword,
         Error
@@ -168,10 +249,14 @@ export default {
         };
     },
     watch: {
-        'connection.key_store'(value) {
-            if (value === 'wp_config') {
+        'connection.key_store'(value, oldValue) {
+            if (value === 'wp_config' && oldValue !== undefined) {
                 this.connection.password = '';
                 this.connection.username = '';
+                this.connection.host = '';
+                this.connection.port = 587;
+                this.connection.encryption = 'tls';
+                this.connection.auth = 'yes';
             }
         }
     },
@@ -181,6 +266,22 @@ export default {
         },
         isDisabledPassword() {
             return this.connection.auth === 'no';
+        },
+        connectionId() {
+            if (this.connection.connection_id !== undefined && this.connection.connection_id !== null) {
+                return this.connection.connection_id;
+            }
+            if (!this.connections) {
+                return 0;
+            }
+            let maxId = -1;
+            jQuery.each(this.connections, (key, conn) => {
+                const id = conn.provider_settings?.connection_id;
+                if (id !== undefined && id !== null) {
+                    maxId = Math.max(maxId, parseInt(id));
+                }
+            });
+            return maxId + 1;
         }
     },
     mounted() {

--- a/resources/admin/Modules/Settings/_GeneralSettings.vue
+++ b/resources/admin/Modules/Settings/_GeneralSettings.vue
@@ -47,8 +47,8 @@
                 <el-select v-model="settings.misc.default_connection">
                     <el-option
                         v-for="(connection, connectionId) in settings.connections"
-                        :key="connectionId"
-                        :value="connectionId"
+                        :key="connection.provider_settings.connection_id !== undefined && connection.provider_settings.connection_id !== null ? connection.provider_settings.connection_id : connectionId"
+                        :value="connection.provider_settings.connection_id !== undefined && connection.provider_settings.connection_id !== null ? connection.provider_settings.connection_id : connectionId"
                         :label="connection.title +' - '+ connection.provider_settings.sender_email"
                     ></el-option>
                 </el-select>
@@ -67,9 +67,9 @@
                 <el-select clearable v-if="connectionsCount > 1" v-model="settings.misc.fallback_connection">
                     <el-option
                         v-for="(connection, connectionId) in settings.connections"
-                        :key="connectionId"
-                        :disabled="settings.misc.default_connection == connectionId"
-                        :value="connectionId"
+                        :key="connection.provider_settings.connection_id !== undefined && connection.provider_settings.connection_id !== null ? connection.provider_settings.connection_id : connectionId"
+                        :disabled="settings.misc.default_connection == (connection.provider_settings.connection_id !== undefined && connection.provider_settings.connection_id !== null ? connection.provider_settings.connection_id : connectionId)"
+                        :value="connection.provider_settings.connection_id !== undefined && connection.provider_settings.connection_id !== null ? connection.provider_settings.connection_id : connectionId"
                         :label="connection.title +' - '+ connection.provider_settings.sender_email"
                     ></el-option>
                 </el-select>

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -53,6 +53,8 @@ return array(
     'FluentMail\\App\\Services\\Mailer\\Providers\\AmazonSes\\SimpleEmailServiceRequest' => $baseDir . '/app/Services/Mailer/Providers/AmazonSes/SimpleEmailServiceRequest.php',
     'FluentMail\\App\\Services\\Mailer\\Providers\\AmazonSes\\Validator' => $baseDir . '/app/Services/Mailer/Providers/AmazonSes/Validator.php',
     'FluentMail\\App\\Services\\Mailer\\Providers\\AmazonSes\\ValidatorTrait' => $baseDir . '/app/Services/Mailer/Providers/AmazonSes/ValidatorTrait.php',
+    'FluentMail\\App\\Services\\Mailer\\Providers\\Cloudflare\\Handler' => $baseDir . '/app/Services/Mailer/Providers/Cloudflare/Handler.php',
+    'FluentMail\\App\\Services\\Mailer\\Providers\\Cloudflare\\ValidatorTrait' => $baseDir . '/app/Services/Mailer/Providers/Cloudflare/ValidatorTrait.php',
     'FluentMail\\App\\Services\\Mailer\\Providers\\DefaultMail\\Handler' => $baseDir . '/app/Services/Mailer/Providers/DefaultMail/Handler.php',
     'FluentMail\\App\\Services\\Mailer\\Providers\\ElasticMail\\Handler' => $baseDir . '/app/Services/Mailer/Providers/ElasticMail/Handler.php',
     'FluentMail\\App\\Services\\Mailer\\Providers\\ElasticMail\\ValidatorTrait' => $baseDir . '/app/Services/Mailer/Providers/ElasticMail/ValidatorTrait.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -85,6 +85,8 @@ class ComposerStaticInit9b719a7d374be78de74c2068943692fe
         'FluentMail\\App\\Services\\Mailer\\Providers\\AmazonSes\\SimpleEmailServiceRequest' => __DIR__ . '/../..' . '/app/Services/Mailer/Providers/AmazonSes/SimpleEmailServiceRequest.php',
         'FluentMail\\App\\Services\\Mailer\\Providers\\AmazonSes\\Validator' => __DIR__ . '/../..' . '/app/Services/Mailer/Providers/AmazonSes/Validator.php',
         'FluentMail\\App\\Services\\Mailer\\Providers\\AmazonSes\\ValidatorTrait' => __DIR__ . '/../..' . '/app/Services/Mailer/Providers/AmazonSes/ValidatorTrait.php',
+        'FluentMail\\App\\Services\\Mailer\\Providers\\Cloudflare\\Handler' => __DIR__ . '/../..' . '/app/Services/Mailer/Providers/Cloudflare/Handler.php',
+        'FluentMail\\App\\Services\\Mailer\\Providers\\Cloudflare\\ValidatorTrait' => __DIR__ . '/../..' . '/app/Services/Mailer/Providers/Cloudflare/ValidatorTrait.php',
         'FluentMail\\App\\Services\\Mailer\\Providers\\DefaultMail\\Handler' => __DIR__ . '/../..' . '/app/Services/Mailer/Providers/DefaultMail/Handler.php',
         'FluentMail\\App\\Services\\Mailer\\Providers\\ElasticMail\\Handler' => __DIR__ . '/../..' . '/app/Services/Mailer/Providers/ElasticMail/Handler.php',
         'FluentMail\\App\\Services\\Mailer\\Providers\\ElasticMail\\ValidatorTrait' => __DIR__ . '/../..' . '/app/Services/Mailer/Providers/ElasticMail/ValidatorTrait.php',


### PR DESCRIPTION
Add support for configuring multiple SMTP connections via `wp-config.php` constants by using an integer suffix (e.g., `_1`, `_2`). Also, migrate connection references, including default and fallback connection mappings, from MD5 hashes to sequential integer IDs.

Closes #400