### PR TITLE
Fix typo in applyFilters key for top menus

### DIFF
--- a/resources/admin/Application.vue
+++ b/resources/admin/Application.vue
@@ -72,7 +72,7 @@
                 ];
             },
             setMenus() {
-                this.items = this.applyFilters('fluentmail_top_menus', this.defaultRoutes());
+                this.items = this.applyFilters('fluent_mail_top_menus', this.defaultRoutes());
                 this.setActive();
             },
             setActive() {


### PR DESCRIPTION
To match resources/admin/Bits/FluentMail.js:158

https://github.com/WPManageNinja/fluent-smtp/blob/5346b2acbf810b0e7314fff375db941b92961390/resources/admin/Bits/FluentMail.js#L158
