### PR TITLE
Add auto-retry for failed emails with exponential backoff

### DIFF
--- a/app/Hooks/Handlers/ActionsRegistrar.php
+++ b/app/Hooks/Handlers/ActionsRegistrar.php
@@ -5,6 +5,7 @@ namespace FluentMail\App\Hooks\Handlers;
 use FluentMail\Includes\Core\Application;
 use FluentMail\App\Hooks\Handlers\AdminMenuHandler;
 use FluentMail\App\Hooks\Handlers\SchedulerHandler;
+use FluentMail\App\Hooks\Handlers\AutoRetryHandler;
 use FluentMail\App\Hooks\Handlers\InitializeSiteHandler;
 use WP_REST_Request;
 
@@ -75,6 +76,7 @@ class ActionsRegistrar
     protected function registerScheduler()
     {
         (new SchedulerHandler)->register();
+        (new AutoRetryHandler)->register();
     }
 
     /**

--- a/app/Hooks/Handlers/AutoRetryHandler.php
+++ b/app/Hooks/Handlers/AutoRetryHandler.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace FluentMail\App\Hooks\Handlers;
+
+use FluentMail\App\Models\Logger;
+use FluentMail\Includes\Support\Arr;
+
+/**
+ * Automatically retries failed email sends with exponential backoff.
+ *
+ * A failed send (primary + fallback) is retried via WP-Cron single events,
+ * reusing the same code path as the manual "Retry" button. Failure
+ * notifications are held back until the final attempt has failed.
+ */
+class AutoRetryHandler
+{
+    const HOOK = 'fluentsmtp_auto_retry_email';
+
+    /* Never schedule when the log row already accumulated this many retries
+       (fallback attempts also increment the counter). */
+    const MAX_TOTAL_RETRIES = 5;
+
+    /* Rows older than this are notified instead of retried (seconds). */
+    const STALE_AFTER = 86400;
+
+    /* Sweep picks up cycles whose next attempt is overdue by this (seconds). */
+    const SWEEP_OVERDUE = 3600;
+
+    public function register()
+    {
+        add_action('fluentmail_email_sending_failed_no_fallback', array($this, 'maybeScheduleRetry'), 5, 3);
+        add_action(self::HOOK, array($this, 'executeRetry'), 10, 2);
+    }
+
+    public static function isEnabled()
+    {
+        $settings = fluentMailGetSettings();
+        return Arr::get($settings, 'misc.auto_retry_failed_emails') == 'yes';
+    }
+
+    public function maybeScheduleRetry($logId, $handler = null, $data = [])
+    {
+        if (!$logId || !self::isEnabled() || defined('FLUENTMAIL_EMAIL_TESTING')) {
+            return;
+        }
+
+        $row = $this->getLogRow($logId);
+
+        if (!$row || $row['status'] !== Logger::STATUS_FAILED) {
+            return;
+        }
+
+        if (Arr::get($row, 'extra.auto_retry')) {
+            // Already part of a retry cycle (including an exhausted one,
+            // when this action is re-fired for the final notification).
+            return;
+        }
+
+        if (intval($row['retries']) >= self::MAX_TOTAL_RETRIES) {
+            return;
+        }
+
+        $this->scheduleAttempt($logId, 1, $row);
+    }
+
+    /**
+     * Whether failure notifications should stay silent for this log row
+     * because an auto-retry attempt is still pending.
+     *
+     * Called from SchedulerHandler::maybeSendNotification at hook priority 10;
+     * maybeScheduleRetry (priority 5) has already stamped the row by then.
+     */
+    public static function willRetry($logId)
+    {
+        // @phpstan-ignore-next-line (new static() for late-static-binding test seams)
+        return (new static())->checkWillRetry($logId);
+    }
+
+    protected function checkWillRetry($logId)
+    {
+        if (!$logId || !self::isEnabled()) {
+            return false;
+        }
+
+        $row = $this->getLogRow($logId);
+
+        if (!$row || $row['status'] !== Logger::STATUS_FAILED) {
+            return false;
+        }
+
+        $stamp = Arr::get($row, 'extra.auto_retry');
+
+        if (!$stamp || !empty($stamp['exhausted'])) {
+            return false;
+        }
+
+        if (intval($row['retries']) >= self::MAX_TOTAL_RETRIES) {
+            return false;
+        }
+
+        return intval(Arr::get($stamp, 'attempt', 0)) <= count($this->getRetryDelays());
+    }
+
+    protected function scheduleAttempt($logId, $attempt, array $row)
+    {
+        $delays = $this->getRetryDelays();
+        $delay = intval($delays[$attempt - 1]);
+        $timestamp = time() + $delay;
+
+        // Stamp before scheduling so a lost/failed schedule is sweep-visible.
+        $this->stampLog($row, array('attempt' => $attempt, 'next_at' => $timestamp));
+
+        wp_schedule_single_event($timestamp, self::HOOK, array(intval($logId), $attempt));
+    }
+
+    protected function getRetryDelays()
+    {
+        $delays = apply_filters('fluentmail_auto_retry_delays', array(120, 900, 3600));
+
+        if (!is_array($delays) || !$delays) {
+            $delays = array(120, 900, 3600);
+        }
+
+        return array_values($delays);
+    }
+
+    protected function getLogRow($logId)
+    {
+        $row = fluentMailDb()->table(FLUENT_MAIL_DB_PREFIX . 'email_logs')
+            ->where('id', intval($logId))
+            ->first();
+
+        if (!$row) {
+            return null;
+        }
+
+        $row = (array)$row;
+
+        if (!empty($row['extra']) && is_string($row['extra']) && is_serialized($row['extra'])) {
+            $row['extra'] = unserialize(trim($row['extra']), array('allowed_classes' => false));
+        }
+
+        return $row;
+    }
+
+    protected function stampLog(array $row, array $stamp)
+    {
+        $extra = isset($row['extra']) && is_array($row['extra']) ? $row['extra'] : array();
+        $existing = isset($extra['auto_retry']) && is_array($extra['auto_retry']) ? $extra['auto_retry'] : array();
+        $extra['auto_retry'] = array_merge($existing, $stamp);
+
+        (new Logger())->updateLog(array(
+            'extra'      => serialize($extra),
+            'updated_at' => current_time('mysql'),
+        ), array('id' => $row['id']));
+    }
+
+    /**
+     * Cron callback: run one retry attempt for a failed email log row.
+     */
+    public function executeRetry($logId, $attempt = 1)
+    {
+        $row = $this->getLogRow($logId);
+
+        if (!$row || $row['status'] !== Logger::STATUS_FAILED) {
+            return; // Sent meanwhile or handled manually.
+        }
+
+        if (!self::isEnabled()) {
+            return; // Feature switched off mid-cycle: leave the row as-is.
+        }
+
+        $this->runResendAttempt($logId);
+
+        $row = $this->getLogRow($logId);
+
+        if (!$row || $row['status'] !== Logger::STATUS_FAILED) {
+            return; // Retry succeeded.
+        }
+
+        $delays = $this->getRetryDelays();
+
+        if ($attempt < count($delays) && intval($row['retries']) < self::MAX_TOTAL_RETRIES) {
+            $this->scheduleAttempt($logId, $attempt + 1, $row);
+            return;
+        }
+
+        $this->finishRetryCycle($row);
+    }
+
+    protected function runResendAttempt($logId)
+    {
+        try {
+            (new Logger())->resendEmailFromLog($logId, 'check_realtime');
+        } catch (\Exception $e) {
+            // A throwing attempt counts as a failed attempt; the row keeps
+            // its 'failed' status and the cycle continues.
+            error_log('FluentSMTP auto-retry attempt failed for log #' . intval($logId) . ': ' . $e->getMessage()); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        }
+    }
+
+    /**
+     * Mark the retry cycle exhausted and release the held-back notification.
+     */
+    protected function finishRetryCycle(array $row)
+    {
+        $this->stampLog($row, array('exhausted' => true));
+
+        $handler = $this->resolveHandler($row);
+
+        if (!$handler) {
+            error_log('FluentSMTP auto-retry: no provider resolvable for final failure notification of log #' . $row['id']); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+            return;
+        }
+
+        do_action('fluentmail_email_sending_failed_no_fallback', $row['id'], $handler, $row);
+    }
+
+    /**
+     * The original in-memory handler object is gone in the cron process;
+     * resolve one from the log row's from address for notification formatting.
+     */
+    protected function resolveHandler(array $row)
+    {
+        $email = $this->extractEmailAddress(Arr::get($row, 'from', ''));
+
+        $handler = $email ? fluentMailGetProvider($email) : false;
+
+        if (!$handler) {
+            $default = fluentMailDefaultConnection();
+            if ($default && !empty($default['sender_email'])) {
+                $handler = fluentMailGetProvider($default['sender_email']);
+            }
+        }
+
+        return $handler;
+    }
+
+    protected function extractEmailAddress($from)
+    {
+        $from = html_entity_decode((string)$from, ENT_QUOTES);
+
+        if (preg_match('/<([^>]+)>/', $from, $matches)) {
+            return trim($matches[1]);
+        }
+
+        return trim($from);
+    }
+
+    /**
+     * Safety net, run from the existing daily scheduled task: rescue retry
+     * cycles whose WP-Cron single event was lost, so no email ends up
+     * neither retried nor notified.
+     */
+    public function sweepStrandedRetries()
+    {
+        if (!self::isEnabled()) {
+            return;
+        }
+
+        $rows = $this->querySweepCandidates();
+
+        foreach ($rows as $rowObj) {
+            $row = $this->getLogRow(is_object($rowObj) ? $rowObj->id : $rowObj['id']);
+
+            if (!$row || $row['status'] !== Logger::STATUS_FAILED) {
+                continue;
+            }
+
+            $stamp = Arr::get($row, 'extra.auto_retry');
+
+            if (!$stamp || !empty($stamp['exhausted'])) {
+                continue;
+            }
+
+            $nextAt = intval(Arr::get($stamp, 'next_at', 0));
+
+            if (!$nextAt || (time() - $nextAt) < self::SWEEP_OVERDUE) {
+                continue; // Not overdue (or malformed): leave to the scheduled event.
+            }
+
+            $attempt = intval(Arr::get($stamp, 'attempt', 1));
+
+            if (wp_next_scheduled(self::HOOK, array(intval($row['id']), $attempt))) {
+                continue; // The event still exists; WP-Cron is merely behind.
+            }
+
+            $createdAt = strtotime($row['created_at'] . ' UTC');
+
+            if ($createdAt && (time() - $createdAt) > self::STALE_AFTER) {
+                // Too old to be worth resending; release the notification.
+                $this->finishRetryCycle($row);
+                continue;
+            }
+
+            $this->executeRetry($row['id'], $attempt);
+        }
+    }
+
+    protected function querySweepCandidates()
+    {
+        return fluentMailDb()->table(FLUENT_MAIL_DB_PREFIX . 'email_logs')
+            ->where('status', Logger::STATUS_FAILED)
+            ->where('extra', 'LIKE', '%auto_retry%')
+            ->where('updated_at', '>', gmdate('Y-m-d H:i:s', time() - 7 * 86400))
+            ->orderBy('id', 'ASC')
+            ->limit(20)
+            ->get();
+    }
+}

--- a/app/Hooks/Handlers/SchedulerHandler.php
+++ b/app/Hooks/Handlers/SchedulerHandler.php
@@ -26,6 +26,11 @@ class SchedulerHandler
     {
         $this->deleteOldEmails();
         $this->sendDailyDigest();
+
+        // Runs last so the sweep's own retry attempts (which define
+        // FLUENTMAIL_LOG_OFF for the rest of this request) don't suppress
+        // logging of the digest email sent above.
+        (new AutoRetryHandler())->sweepStrandedRetries();
     }
 
     private function deleteOldEmails()
@@ -258,6 +263,12 @@ class SchedulerHandler
 
     public function maybeSendNotification($rowId, $handler, $logData = [])
     {
+        if (AutoRetryHandler::willRetry($rowId)) {
+            // An auto-retry attempt is pending; notify only if the final
+            // attempt also fails (AutoRetryHandler re-fires this action then).
+            return false;
+        }
+
         $lastNotificationSent = get_option('_fsmtp_last_notification_sent');
         if ($lastNotificationSent && (time() - $lastNotificationSent) < 60) {
             return false;

--- a/app/Services/Mailer/Providers/config.php
+++ b/app/Services/Mailer/Providers/config.php
@@ -275,10 +275,11 @@ return [
         ],
     ],
     'misc'        => [
-        'log_emails'              => 'yes',
-        'log_saved_interval_days' => '14',
-        'disable_fluentcrm_logs'  => 'no',
-        'default_connection'      => '',
-        'fallback_connection'     => ''
+        'log_emails'               => 'yes',
+        'log_saved_interval_days'  => '14',
+        'disable_fluentcrm_logs'   => 'no',
+        'default_connection'       => '',
+        'fallback_connection'      => '',
+        'auto_retry_failed_emails' => 'no'
     ]
 ];

--- a/app/Services/TransStrings.php
+++ b/app/Services/TransStrings.php
@@ -135,6 +135,8 @@ class TransStrings
             'Failed to load notification channels' => __('Failed to load notification channels', 'fluent-smtp'),
             'Failed to toggle channel' => __('Failed to toggle channel', 'fluent-smtp'),
             'Fallback Connection' => __('Fallback Connection', 'fluent-smtp'),
+            'Auto-Retry Failed Emails' => __('Auto-Retry Failed Emails', 'fluent-smtp'),
+            '__auto_retry_label' => __('Automatically retry failed emails (up to 3 attempts with increasing delays)', 'fluent-smtp'),
             'Fastest Contact Form Builder Plugin for WordPress' => __('Fastest Contact Form Builder Plugin for WordPress', 'fluent-smtp'),
             'Filter' => __('Filter', 'fluent-smtp'),
             'FluentCRM Email Logging' => __('FluentCRM Email Logging', 'fluent-smtp'),

--- a/resources/admin/Modules/Settings/_GeneralSettings.vue
+++ b/resources/admin/Modules/Settings/_GeneralSettings.vue
@@ -94,6 +94,14 @@
                 >{{$t('__Email_TEXT_PART_Label')}}</el-checkbox>
             </el-form-item>
 
+            <el-form-item :label="$t('Auto-Retry Failed Emails')">
+                <el-checkbox
+                    v-model="settings.misc.auto_retry_failed_emails"
+                    true-label="yes"
+                    false-label="no"
+                >{{$t('__auto_retry_label')}}</el-checkbox>
+            </el-form-item>
+
             <el-button
                 v-loading="saving"
                 @click="saveMiscSettings()"


### PR DESCRIPTION
## What

Adds an opt-in **auto-retry for failed emails**: when a send fails (including
after the fallback connection was tried), FluentSMTP schedules up to 3
automatic retries at increasing delays (2 min / 15 min / 60 min) using
per-email WP-Cron single events. Failure-channel notifications
(Slack/Telegram/Discord/Pushover) are held back until the final attempt has
failed, so transient blips that self-heal never alert anyone — while the email
log still records every attempt.

Off by default. One checkbox under **Settings → General Settings**:
"Auto-Retry Failed Emails". Developers can tune the schedule via the
`fluentmail_auto_retry_delays` filter.

## Why

Transient failures are a fact of life for every provider: rate limits, brief
outages, network blips, expired OAuth tokens. Today a single failed attempt
fails the email permanently — even though, as #265 and #156 document, clicking
**Retry** moments later almost always delivers. This PR automates exactly that
manual retry.

## How

- New `AutoRetryHandler` hooks the existing
  `fluentmail_email_sending_failed_no_fallback` action (priority 5) and
  schedules `fluentsmtp_auto_retry_email` single events per log row.
- Retries reuse `Logger::resendEmailFromLog($id, 'check_realtime')` — the
  exact code path behind the manual Retry button — so log-status semantics
  match the manual Retry button exactly. Like the manual Retry button, a
  retry attempt is routed via the sender's primary connection — the fallback
  connection is not re-invoked mid-retry (a row only enters the retry cycle
  after primary and fallback have both failed).
- Retry state (attempt number, next-due timestamp) is stamped into the log
  row's existing `extra` blob; the existing `retries` column keeps counting
  attempts. **No schema changes, no new endpoints, no new log status.**
- `SchedulerHandler::maybeSendNotification` gets a one-line gate:
  `AutoRetryHandler::willRetry($rowId)` — notifications fire immediately when
  auto-retry is off (unchanged behavior) or once the last attempt failed.
- A sweep on the existing daily task rescues cycles whose single event was
  lost (or, for emails older than 24 h, releases the notification), so no
  email can end up neither retried nor notified.
- Guards: manual-retry races (row re-checked before each attempt), test
  emails excluded, hard cap of 5 total recorded retries, exhausted cycles
  can't be re-entered.

## Known limitations

- Retry attempts reuse the existing resend path, which defines the
  `FLUENTMAIL_LOG_OFF` constant for the remainder of the PHP process — exactly
  as the manual Retry button does in its admin-ajax request. In a WP-Cron
  spawn this means an unrelated email sent later in that same spawn is not
  logged. Threading this through `resendEmailFromLog()` as a parameter instead
  of a constant would remove the limitation; I kept this PR surgical, but I'm
  happy to include that change here or as a follow-up.
- Disabling the toggle mid-cycle stops pending retries; since the
  first-failure notification was held back, that email's failure is then
  visible only in the email log. Re-enabling within 7 days lets the daily
  sweep resume stranded cycles.
- With the feature enabled, `fluentmail_email_sending_failed_no_fallback`
  fires both at the original failure (as today) and once more when the retry
  cycle exhausts, so third-party listeners of that action see a second
  invocation per exhausted email.

## Relationship to PR #311

#311 pioneered auto-retry (thanks @kennydude!) but has a few structural
issues this PR avoids: an hourly cron that retries at most one email per run,
an unauthenticated `wp_ajax_nopriv` trigger endpoint, a new `autoresend` log
status that leaks into stats/filters, no backoff, and cron/notification
callbacks that error in cron context. This implementation needs no new
endpoints or statuses and retries each email on its own schedule.

## Testing

Verified end-to-end against a real WordPress install (wp-env), driving an
actual failing SMTP connection through the full retry cycle:

- **Failed send schedules the first retry, no notification yet.** A send
  against a broken connection lands in the log as `failed`, stamps
  `auto_retry` attempt 1 into the row's `extra` data, and schedules exactly
  one `fluentsmtp_auto_retry_email` cron event ~2 minutes out. No failure
  notification is recorded at this point.
- **Escalation across attempts 1 → 2 → 3.** Driving the pending cron event
  three times in a row against the still-broken connection increments
  `retries` 1 → 2 → 3, with each subsequent event scheduled further out
  (~2 min → ~15 min → ~60 min, matching the configured backoff). After the
  third attempt, no further retry event is scheduled and the failure
  notification is released — visible as the `_fsmtp_last_notification_sent`
  option being set for the first time.
- **Recovery mid-cycle.** With a fresh failing send scheduled for retry,
  fixing the underlying connection and letting the pending cron event fire
  flips the log row straight to `sent` (`retries=1`) with zero pending
  `fluentsmtp_auto_retry_email` events left — the cycle stops cleanly on
  success and no notification ever fires.
- **UI toggle.** The "Auto-Retry Failed Emails" checkbox renders under
  Settings → General Settings, toggles in both directions, and both states
  persist to the `fluentmail-settings` option across a page reload.

Additionally, a standalone 22-scenario test suite covering scheduling,
notification gating, retry execution (success/failure/exhaustion/race),
address extraction, and the sweep logic passes against the exact code in this
PR. The suite is not part of this PR's diff (this repo has no test
infrastructure to hook into); it lives on our fork if you want to run it
against this branch locally:
https://github.com/RhinoBag/fluent-smtp/tree/feature/auto-retry-failed-emails/tests/retry
— checkout, then `php tests/retry/run_tests.php` (plain PHP CLI, no
WordPress or database needed).

<details>
<summary>Trimmed evidence from the end-to-end run</summary>

Failed send → log row + scheduled retry, no notification yet:

```
$ wp db query 'SELECT id, status, retries, extra FROM wp_fsmpt_email_logs ORDER BY id DESC LIMIT 1'
1  failed  0  a:2:{s:8:"provider";s:4:"smtp";s:10:"auto_retry";a:2:{s:7:"attempt";i:1;s:7:"next_at";i:1783971021;}}

$ wp cron event list --fields=hook,next_run_relative | grep fluentsmtp_auto_retry_email
fluentsmtp_auto_retry_email  1 minute 52 seconds

$ wp option get _fsmtp_last_notification_sent
Error: Could not get '_fsmtp_last_notification_sent' option. Does it exist?
```

Attempts 1 → 2 → 3, backoff escalating, notification released only at the end:

```
# attempt 1
$ wp cron event run fluentsmtp_auto_retry_email
$ wp db query 'SELECT id, status, retries FROM wp_fsmpt_email_logs ORDER BY id DESC LIMIT 1'
1  failed  1
$ wp cron event list --fields=hook,next_run_relative
fluentsmtp_auto_retry_email  14 minutes 57 seconds

# attempt 2
$ wp cron event run fluentsmtp_auto_retry_email
$ wp db query 'SELECT id, status, retries FROM wp_fsmpt_email_logs ORDER BY id DESC LIMIT 1'
1  failed  2
$ wp cron event list --fields=hook,next_run_relative
fluentsmtp_auto_retry_email  59 minutes 57 seconds

# attempt 3
$ wp cron event run fluentsmtp_auto_retry_email
$ wp db query 'SELECT id, status, retries FROM wp_fsmpt_email_logs ORDER BY id DESC LIMIT 1'
1  failed  3
$ wp cron event list --fields=hook,next_run_relative
(no fluentsmtp_auto_retry_email row present)
$ wp option get _fsmtp_last_notification_sent
1783970953
```

Recovery mid-cycle — connection fixed before the pending retry fires:

```
$ wp cron event run fluentsmtp_auto_retry_email
$ wp db query 'SELECT id, status, retries FROM wp_fsmpt_email_logs ORDER BY id DESC LIMIT 1'
3  sent  1
$ wp cron event list --fields=hook | grep -c fluentsmtp_auto_retry_email || echo "0 pending"
0
0 pending
```

Test suite run against this PR's code:

```
$ php tests/retry/run_tests.php
...
All scenarios passed.
```

</details>

Happy to adjust delays/attempts, naming, or UI copy to your preferences.
