### PR TITLE
Fix Outlook sending with empty Bearer token after failed refresh (#265)

### DIFF
--- a/app/Services/Mailer/Providers/Outlook/API.php
+++ b/app/Services/Mailer/Providers/Outlook/API.php
@@ -50,6 +50,10 @@ class API
      */
     public function sendMime($mime, $accessToken)
     {
+        if (empty($accessToken) || is_wp_error($accessToken) || !is_string($accessToken)) {
+            return new \WP_Error(401, __('Outlook API Error: No valid access token available. Please re-authenticate the connection.', 'fluent-smtp'));
+        }
+
         $response = wp_remote_request('https://graph.microsoft.com/v1.0/me/sendMail', [
             'method'  => 'POST',
             'headers' => [
@@ -66,15 +70,16 @@ class API
         $responseCode = wp_remote_retrieve_response_code($response);
 
         if ($responseCode >= 300) {
-            $error = Arr::get($response, 'response.message');
+            $responseBody = json_decode(wp_remote_retrieve_body($response), true);
+
+            $error = Arr::get($responseBody, 'error.message');
 
             if (!$error) {
-                $responseBody = json_decode(wp_remote_retrieve_body($response), true);
+                $error = Arr::get($response, 'response.message');
+            }
 
-                $error = Arr::get($responseBody, 'error.message');
-                if (!$error) {
-                    $error = __('Something with wrong with Outlook API. Please check your API Settings', 'fluent-smtp');
-                }
+            if (!$error) {
+                $error = __('Something went wrong with the Outlook API. Please check your API Settings', 'fluent-smtp');
             }
 
             return new \WP_Error($responseCode, $error);

--- a/app/Services/Mailer/Providers/Outlook/Handler.php
+++ b/app/Services/Mailer/Providers/Outlook/Handler.php
@@ -53,6 +53,10 @@ class Handler extends BaseHandler
 
         $accessToken = $this->getAccessToken($data);
 
+        if (is_wp_error($accessToken)) {
+            return new \WP_Error(422, __('Failed to refresh the Outlook access token: ', 'fluent-smtp') . $accessToken->get_error_message(), []);
+        }
+
         $api = (new API($data['client_id'], $data['client_secret']));
 
         $result = $api->sendMime($mime, $accessToken);
@@ -165,8 +169,8 @@ class Handler extends BaseHandler
                 'refresh_token' => $config['refresh_token']
             ]);
 
-            if(is_wp_error($tokens)) {
-                return false;
+            if (is_wp_error($tokens)) {
+                return $tokens;
             }
 
             $this->saveNewTokens($config, $tokens);

--- a/includes/OAuth2Provider.php
+++ b/includes/OAuth2Provider.php
@@ -186,20 +186,31 @@ class OAuth2Provider
         }
 
         $responseBody = wp_remote_retrieve_body($response);
+        $responseCode = wp_remote_retrieve_response_code($response);
 
-        if (false === is_array($response)) {
+        $tokens = \json_decode($responseBody, true);
+
+        if (!is_array($tokens)) {
             throw new \Exception(
                 'Invalid response received from Authorization Server. Expected JSON.'
             );
         }
 
-        if(empty(['access_token'])) {
+        if (!empty($tokens['error'])) {
+            $errorMessage = $tokens['error'];
+            if (!empty($tokens['error_description'])) {
+                $errorMessage .= ': ' . $tokens['error_description'];
+            }
+            throw new \Exception(wp_kses_post($errorMessage)); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+        }
+
+        if ($responseCode >= 300 || empty($tokens['access_token'])) {
             throw new \Exception(
-                'Invalid response received from Authorization Server.'
+                'Authorization Server returned HTTP ' . intval($responseCode) . ' without an access token.'
             );
         }
 
-        return \json_decode($responseBody, true);
+        return $tokens;
     }
 
 


### PR DESCRIPTION

Fixes #265.

## The bug

Outlook/Microsoft 365 connections intermittently fail to send with a
logged error of `{"code": 422, "message": "Unauthorized"}`, and a manual
Retry always succeeds. This is caused by three separate issues in the
token-refresh path that only produce a visible failure when they line up:

1. `OAuth2Provider::getAccessToken()` has a dead validation check —
   `empty(['access_token'])` checks a literal array, not the actual
   response, so it's always `false` and never throws. An error response
   from Microsoft's token endpoint (e.g. `invalid_grant`) is silently
   treated as a successful response with no `access_token` key.
2. `Outlook\Handler::getAccessToken()` discards the real error when a
   refresh HTTP call itself fails, returning bare `false` instead of the
   underlying `WP_Error`.
3. `Outlook\API::sendMime()` has no guard against an empty/invalid token —
   it sends `Authorization: Bearer ` (empty) to Microsoft Graph regardless,
   and its error-message extraction checks the generic HTTP reason phrase
   (`"Unauthorized"`) before Microsoft's actual error body, so the real
   reason is always discarded in favor of a generic one.

Because Outlook tokens are refreshed lazily at send time (there's no
proactive renewal cron, unlike the Gmail provider), low-traffic sites hit
the refresh path on nearly every send — so any transient hiccup in that
refresh round-trip becomes a failed send with a misleading
"Unauthorized." Retrying always works because the next send just runs the
refresh again from a clean state.

## The fix

- Make the token-response validation real: throw with Microsoft's actual
  `error`/`error_description` on a bad token response, instead of a dead
  check that never fires.
- Propagate refresh failures as `WP_Error` instead of swallowing them into
  `false`, and check for that error before attempting to send.
- Refuse to send with an empty/invalid access token (before any HTTP
  request goes out), and prefer Microsoft Graph's own error body over the
  generic HTTP reason phrase when reporting a send failure.

## Verification

A small standalone script exercises the real `OAuth2Provider`, `Handler`,
and `API` classes against stubbed WordPress functions, covering: a failed
refresh request, a malformed/error token response, an empty/invalid token
reaching `sendMime()`, a regression check that a healthy refresh is
unaffected, and the error-message precedence. The script lives on our
fork (it is not part of this PR's diff, since this repo has no test
infrastructure to hook into):
https://github.com/RhinoBag/fluent-smtp/blob/fix/outlook-token-refresh/tests/verify_outlook_fix.php
— checkout that branch, then `php tests/verify_outlook_fix.php` (plain
PHP CLI, no WordPress or database needed).

<details>
<summary>php tests/verify_outlook_fix.php — 12/12 PASS</summary>

```
[PASS] A: refresh failure returns WP_Error (not false)
[PASS] A: real cURL error is preserved
[PASS] B: HTTP 400 invalid_grant throws
[PASS] B: exception carries error code and description
[PASS] B: Handler returns WP_Error with descriptive message
[PASS] B2: healthy refresh unchanged
[PASS] C: sendMime(boolean) refuses without crashing
[PASS] C: sendMime(string) refuses without crashing
[PASS] C: sendMime(NULL) refuses without crashing
[PASS] C: sendMime(object) refuses without crashing
[PASS] C: no HTTP request left the process
[PASS] D: body message surfaces instead of reason phrase

All fixed-behavior checks passed.
```
</details>

`OAuth2Provider` is only used by the Outlook provider (verified by grep),
so this doesn't touch Gmail, SES, SendGrid, or any other integration.

For any connection that's currently healthy, nothing changes — the fix
only changes what happens on paths that were previously silent or
misleading failures: refresh errors now log the real reason, invalid
auth codes are rejected at connect time instead of being saved and
failing later, and send failures report Microsoft's actual error message
instead of a generic "Unauthorized."

Deliberately out of scope (possible follow-up if you're interested):
proactive Outlook token renewal on a cron, mirroring the existing
`fluentsmtp_renew_gmail_token` pattern, so the refresh happens off the
send path in the first place.
