### PR TITLE
Fix &amp; encoding in From Name and Subject (#361)

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -75,6 +75,9 @@ class SettingsController extends Controller
 
                 if (is_string($value) && $value) {
                     $connection[$index] = sanitize_text_field($value);
+                    if ($index === 'sender_name') {
+                        $connection[$index] = html_entity_decode($connection[$index], ENT_QUOTES, 'UTF-8');
+                    }
                 }
             }
 

--- a/app/Services/Mailer/BaseHandler.php
+++ b/app/Services/Mailer/BaseHandler.php
@@ -60,7 +60,7 @@ class BaseHandler
         $this->attributes = [];
         
         if ($this->isForced('from_name')) {
-            $this->phpMailer->FromName = $this->getSetting('sender_name');
+            $this->phpMailer->FromName = html_entity_decode($this->getSetting('sender_name'), ENT_QUOTES, 'UTF-8');
         }
 
         if ($this->getSetting('return_path') == 'yes') {
@@ -135,7 +135,7 @@ class BaseHandler
 
     protected function setFrom()
     {
-        $name = $this->getSetting('sender_name');
+        $name = html_entity_decode($this->getSetting('sender_name'), ENT_QUOTES, 'UTF-8');
         $email = $this->getSetting('sender_email');
         $overrideName = $this->getSetting('force_from_name');
 
@@ -145,8 +145,8 @@ class BaseHandler
             $from = $name . ' <' . $email . '>';
         } elseif ($this->phpMailer->FromName) {
             $this->attributes['sender_email'] = $email;
-            $this->attributes['sender_name'] = $this->phpMailer->FromName;
-            $from = $this->phpMailer->FromName . ' <' . $email . '>';
+            $this->attributes['sender_name'] = html_entity_decode($this->phpMailer->FromName, ENT_QUOTES, 'UTF-8');
+            $from = $this->attributes['sender_name'] . ' <' . $email . '>';
         } else {
             $from = $this->attributes['sender_email'] = $email;
         }
@@ -240,7 +240,7 @@ class BaseHandler
         $subject = '';
 
         if (isset($this->attributes['subject'])) {
-            $subject = $this->attributes['subject'];
+            $subject = html_entity_decode($this->attributes['subject'], ENT_QUOTES, 'UTF-8');
         }
 
         return $subject;
@@ -289,7 +289,7 @@ class BaseHandler
             $data = [
                 'to' => $this->serialize($this->attributes['to']),
                 'from' => $this->attributes['from'],
-                'subject' => sanitize_text_field($this->attributes['subject']),
+                'subject' => html_entity_decode(sanitize_text_field($this->attributes['subject']), ENT_QUOTES, 'UTF-8'),
                 'body' => $this->attributes['message'],
                 'attachments' => $this->serialize($this->attributes['attachments']),
                 'status'   => $status ? 'sent' : 'failed',

--- a/app/Services/Mailer/Providers/Smtp/Handler.php
+++ b/app/Services/Mailer/Providers/Smtp/Handler.php
@@ -47,13 +47,13 @@ class Handler extends BaseHandler
             }
 
             if (isset($this->phpMailer->FromName)) {
-                $fromName = $this->phpMailer->FromName;
+                $fromName = html_entity_decode($this->phpMailer->FromName, ENT_QUOTES, 'UTF-8');
 
                 if (
                     $this->getSetting('force_from_name') == 'yes' &&
                     $customFrom = $this->getSetting('sender_name')
                 ) {
-                    $fromName = $customFrom;
+                    $fromName = html_entity_decode($customFrom, ENT_QUOTES, 'UTF-8');
                 }
 
                 $this->phpMailer->setFrom($fromEmail, $fromName);

--- a/app/Services/Mailer/Providers/ToSend/Handler.php
+++ b/app/Services/Mailer/Providers/ToSend/Handler.php
@@ -104,11 +104,11 @@ class Handler extends BaseHandler
 
         $fromName = '';
         if (isset($this->phpMailer->FromName)) {
-            $fromName = $this->phpMailer->FromName;
+            $fromName = html_entity_decode($this->phpMailer->FromName, ENT_QUOTES, 'UTF-8');
             if ($this->getSetting('force_from_name') == 'yes' &&
                 $customFrom = $this->getSetting('sender_name')
             ) {
-                $fromName = $customFrom;
+                $fromName = html_entity_decode($customFrom, ENT_QUOTES, 'UTF-8');
             }
         }
 


### PR DESCRIPTION
This PR fixes issue #361 where the `&` character in email From Name and Subject was being encoded as `&amp;`.

**Root Cause:** `sanitize_text_field()` in WordPress encodes `&` → `&amp;`. This affected:
1. **Settings save** — `SettingsController::store()` applied it to `sender_name`
2. **Email logging** — `BaseHandler::processResponse()` applied it to the subject

**Changes:**

| File | Fix |
|------|-----|
| `app/Http/Controllers/SettingsController.php` | Decode `sender_name` after `sanitize_text_field()` on save |
| `app/Services/Mailer/BaseHandler.php` | Decode From Name + Subject in `preSend()`, `setFrom()`, `getSubject()`, `processResponse()` |
| `Providers/Smtp/Handler.php` | Decode From Name in SMTP handler |
| `Providers/ToSend/Handler.php` | Decode From Name in ToSend handler |

Applied `html_entity_decode($value, ENT_QUOTES, 'UTF-8')` at both save-time and send-time for defense in depth.

@techjewel