### PR TITLE
Add Import/Export Connections feature (#369)

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -173,21 +173,22 @@ class SettingsController extends Controller
         $this->verify();
 
         try {
-            $data = $request->except(['action', 'nonce']);
-            $importData = json_decode(wp_unslash($data['import_data']), true);
+            $input = json_decode(file_get_contents('php://input'), true);
 
-            if (!$importData || !isset($importData['connections']) || empty($importData['connections'])) {
+            if (!$input || !isset($input['import_data']) || empty($input['import_data'])) {
                 return $this->sendError([
-                    'message' => __('Invalid import data. No connections found in the file.', 'fluent-smtp')
+                    'message' => __('Invalid import data. No connections found in the request.', 'fluent-smtp')
                 ], 422);
             }
+
+            $importData = json_decode(wp_unslash($input['import_data']), true);
 
             $connections = $importData['connections'];
             $importMappings = isset($importData['mappings']) ? $importData['mappings'] : [];
 
             // Validate provider keys exist in current plugin config
             $currentSettings = $settings->get();
-            $availableProviders = Arr::get($currentSettings, 'providers', []);
+            $availableProviders = fluentMail('manager')->getConfig('providers');
 
             $validatedConnections = [];
             $skippedCount = 0;
@@ -212,7 +213,7 @@ class SettingsController extends Controller
                 ], 422);
             }
 
-            $mode = Arr::get($data, 'mode', 'merge');
+            $mode = Arr::get($input, 'mode', 'merge');
 
             if ($mode === 'replace') {
                 $currentSettings['connections'] = $validatedConnections;

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -139,6 +139,130 @@ class SettingsController extends Controller
         ]);
     }
 
+    public function exportConnections(Settings $settings)
+    {
+        $this->verify();
+
+        try {
+            $settingsData = $settings->get();
+            $connections = Arr::get($settingsData, 'connections', []);
+            $mappings = Arr::get($settingsData, 'mappings', []);
+
+            $exportData = [
+                'version'      => '1.0',
+                'exported_at'  => current_time('c'),
+                'source_url'   => site_url(),
+                'plugin_version' => FLUENTMAIL_PLUGIN_VERSION,
+                'connections'  => $connections,
+                'mappings'     => $mappings,
+            ];
+
+            return $this->sendSuccess([
+                'export_data' => $exportData,
+                'message'     => __('Connections exported successfully.', 'fluent-smtp')
+            ]);
+        } catch (Exception $e) {
+            return $this->sendError([
+                'message' => $e->getMessage()
+            ], $e->getCode());
+        }
+    }
+
+    public function importConnections(Request $request, Settings $settings)
+    {
+        $this->verify();
+
+        try {
+            $data = $request->except(['action', 'nonce']);
+            $importData = json_decode(wp_unslash($data['import_data']), true);
+
+            if (!$importData || !isset($importData['connections']) || empty($importData['connections'])) {
+                return $this->sendError([
+                    'message' => __('Invalid import data. No connections found in the file.', 'fluent-smtp')
+                ], 422);
+            }
+
+            $connections = $importData['connections'];
+            $importMappings = isset($importData['mappings']) ? $importData['mappings'] : [];
+
+            // Validate provider keys exist in current plugin config
+            $currentSettings = $settings->get();
+            $availableProviders = Arr::get($currentSettings, 'providers', []);
+
+            $validatedConnections = [];
+            $skippedCount = 0;
+            $addedCount = 0;
+
+            foreach ($connections as $key => $connection) {
+                $providerKey = Arr::get($connection, 'provider_settings.provider');
+
+                if (!$providerKey || !isset($availableProviders[$providerKey])) {
+                    $skippedCount++;
+                    continue;
+                }
+
+                $validatedConnections[$key] = $connection;
+            }
+
+            $addedCount = count($validatedConnections);
+
+            if ($addedCount === 0) {
+                return $this->sendError([
+                    'message' => __('None of the connections could be imported. The provider(s) may not be available in this installation.', 'fluent-smtp')
+                ], 422);
+            }
+
+            $mode = Arr::get($data, 'mode', 'merge');
+
+            if ($mode === 'replace') {
+                $currentSettings['connections'] = $validatedConnections;
+                $currentSettings['mappings'] = $importMappings;
+            } else {
+                // Merge: add/overwrite individual connections
+                foreach ($validatedConnections as $key => $connection) {
+                    $currentSettings['connections'][$key] = $connection;
+                }
+                // Also merge mappings
+                foreach ($importMappings as $email => $connectionKey) {
+                    $currentSettings['mappings'][$email] = $connectionKey;
+                }
+
+                // Clean up orphaned mappings
+                if ($currentSettings['mappings'] && $currentSettings['connections']) {
+                    $validMappings = array_keys(Arr::get($currentSettings, 'connections', []));
+                    $currentSettings['mappings'] = array_filter($currentSettings['mappings'], function ($key) use ($validMappings) {
+                        return in_array($key, $validMappings);
+                    });
+                }
+            }
+
+            fluentMailSetSettings($currentSettings);
+
+            $summary = sprintf(
+                __('%d connection(s) imported successfully.', 'fluent-smtp'),
+                $addedCount
+            );
+
+            if ($skippedCount > 0) {
+                $summary .= ' ' . sprintf(
+                    __('%d connection(s) skipped (provider not available).', 'fluent-smtp'),
+                    $skippedCount
+                );
+            }
+
+            return $this->sendSuccess([
+                'message'     => $summary,
+                'connections' => $settings->getConnections(),
+                'mappings'    => $settings->getMappings(),
+                'misc'        => $settings->getMisc()
+            ]);
+        } catch (Exception $e) {
+            return $this->sendError([
+                'message' => $e->getMessage()
+            ], $e->getCode());
+        }
+    }
+
     public function sendTestEmil(Request $request, Settings $settings)
     {
         $this->verify();

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -11,6 +11,8 @@ $app->post('/misc-settings', 'SettingsController@storeMiscSettings');
 $app->post('/settings/delete', 'SettingsController@delete');
 $app->post('/settings/misc', 'SettingsController@storeGlobals');
 $app->post('/settings/test', 'SettingsController@sendTestEmil');
+$app->get('settings/export-connections', 'SettingsController@exportConnections');
+$app->post('settings/import-connections', 'SettingsController@importConnections');
 $app->post('/settings/subscribe', 'SettingsController@subscribe');
 $app->post('/settings/subscribe-dismiss', 'SettingsController@subscribeDismiss');
 $app->get('settings/connection_info', 'SettingsController@getConnectionInfo');

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "sass": "^1.36.0",
         "sass-loader": "^12.1.0",
         "vue-loader": "^15.9.7",
-        "vue-template-compiler": "^2.6.14"
+        "vue-template-compiler": "^2.6.14",
+        "webpackbar": "^7.0.0"
     },
     "dependencies": {
         "chart.js": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
         "vue": "^2.6.14",
         "vue-chartjs": "^3.5.1",
         "vue-router": "^3.5.2"
+    },
+    "allowScripts": {
+        "@parcel/watcher@2.6.0": true,
+        "core-js@2.6.12": true
     }
 }

--- a/resources/admin/Modules/Settings/Connections.vue
+++ b/resources/admin/Modules/Settings/Connections.vue
@@ -7,11 +7,25 @@
                         <span style="float:left;">
                             {{$t('Active Email Connections')}}
                         </span>
-                        <span
-                            style="float:right;color:#46A0FC;cursor:pointer;"
-                            @click="addConnection"
-                        >
-                            <i class="el-icon-plus"></i> {{$t('Add Another Connection')}}
+                        <span style="float:right;">
+                            <span
+                                style="color:#67C23A;cursor:pointer;margin-right:16px;"
+                                @click="exportConnections"
+                            >
+                                <i class="el-icon-download"></i> {{$t('Export')}}
+                            </span>
+                            <span
+                                style="color:#46A0FC;cursor:pointer;margin-right:16px;"
+                                @click="showImportDialog = true"
+                            >
+                                <i class="el-icon-upload2"></i> {{$t('Import')}}
+                            </span>
+                            <span
+                                style="color:#46A0FC;cursor:pointer;"
+                                @click="addConnection"
+                            >
+                                <i class="el-icon-plus"></i> {{$t('Add Another Connection')}}
+                            </span>
                         </span>
                     </div>
                     <div class="fss_content">
@@ -91,6 +105,61 @@
                 </div>
             </el-col>
         </el-row>
+
+        <el-dialog
+            :title="$t('Import Connections')"
+            :visible.sync="showImportDialog"
+            width="500px"
+            :close-on-click-modal="false"
+        >
+            <div style="padding: 10px 0;">
+                <p style="margin-bottom: 15px; color: #666;">
+                    {{ $t('Select a JSON file exported from another FluentSMTP installation. The connections will be imported and merged with your existing ones.') }}
+                </p>
+                <el-upload
+                    ref="importUpload"
+                    :auto-upload="false"
+                    :on-change="onImportFileChange"
+                    :on-remove="onImportFileRemove"
+                    accept=".json"
+                    :limit="1"
+                    action="#"
+                >
+                    <el-button size="small" type="primary">
+                        <i class="el-icon-document"></i> {{ $t('Select JSON File') }}
+                    </el-button>
+                    <div slot="tip" class="el-upload__tip" style="color: #999;">
+                        {{ $t('Only .json files are accepted') }}
+                    </div>
+                </el-upload>
+
+                <div v-if="importPreview" style="margin-top: 20px; padding: 15px; background: #f9f9f9; border-radius: 4px;">
+                    <p style="font-weight: 600; margin-bottom: 10px;">
+                        <i class="el-icon-info" style="color: #409EFF;"></i>
+                        {{ $t('Connections to import:') }}
+                    </p>
+                    <div v-for="(conn, key) in importPreview" :key="key" style="padding: 6px 0; border-bottom: 1px solid #eee; font-size: 13px;">
+                        <strong>{{ conn.title }}</strong>
+                        <span style="color: #999;"> — {{ conn.provider_settings?.sender_email || 'N/A' }}</span>
+                    </div>
+                    <el-radio-group v-model="importMode" style="margin-top: 15px;">
+                        <el-radio label="merge">{{ $t('Merge with existing connections') }}</el-radio>
+                        <el-radio label="replace">{{ $t('Replace all existing connections') }}</el-radio>
+                    </el-radio-group>
+                </div>
+            </div>
+            <span slot="footer">
+                <el-button @click="closeImportDialog">{{ $t('Cancel') }}</el-button>
+                <el-button
+                    type="primary"
+                    :disabled="!importFileContent"
+                    :loading="importing"
+                    @click="importConnections"
+                >
+                    {{ $t('Import') }}
+                </el-button>
+            </span>
+        </el-dialog>
     </div>
 </template>
 
@@ -111,7 +180,12 @@
         data() {
             return {
                 showing_connection: '',
-                active_settings: 'general'
+                active_settings: 'general',
+                showImportDialog: false,
+                importFileContent: null,
+                importPreview: null,
+                importing: false,
+                importMode: 'merge'
             };
         },
         methods: {
@@ -157,6 +231,112 @@
                 this.$nextTick(() => {
                     this.showing_connection = connection.unique_key;
                 });
+            },
+            async exportConnections() {
+                try {
+                    const response = await this.$get('settings/export-connections');
+                    const exportData = response.data.export_data;
+                    const json = JSON.stringify(exportData, null, 2);
+                    const blob = new Blob([json], { type: 'application/json' });
+                    const url = URL.createObjectURL(blob);
+                    const link = document.createElement('a');
+                    link.href = url;
+                    link.download = 'fluent-smtp-connections-' + exportData.source_url.replace(/[^a-z0-9]/gi, '-') + '.json';
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+                    URL.revokeObjectURL(url);
+
+                    this.$notify.success({
+                        title: this.$t('Exported'),
+                        message: this.$t('Connections exported successfully.'),
+                        offset: 19
+                    });
+                } catch (error) {
+                    this.$notify.error({
+                        title: this.$t('Export Failed'),
+                        message: error.message || this.$t('An error occurred while exporting connections.'),
+                        offset: 19
+                    });
+                }
+            },
+            onImportFileChange(file) {
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    try {
+                        const data = JSON.parse(e.target.result);
+                        if (!data.connections || Object.keys(data.connections).length === 0) {
+                            this.$notify.error({
+                                title: this.$t('Invalid File'),
+                                message: this.$t('The selected file does not contain any connections.'),
+                                offset: 19
+                            });
+                            this.importFileContent = null;
+                            this.importPreview = null;
+                            return;
+                        }
+                        this.importFileContent = e.target.result;
+                        this.importPreview = data.connections;
+                    } catch (err) {
+                        this.$notify.error({
+                            title: this.$t('Invalid File'),
+                            message: this.$t('The selected file is not a valid JSON file.'),
+                            offset: 19
+                        });
+                        this.importFileContent = null;
+                        this.importPreview = null;
+                    }
+                };
+                reader.readAsText(file.raw);
+            },
+            onImportFileRemove() {
+                this.importFileContent = null;
+                this.importPreview = null;
+            },
+            closeImportDialog() {
+                this.showImportDialog = false;
+                this.importFileContent = null;
+                this.importPreview = null;
+                this.importing = false;
+                this.importMode = 'merge';
+                if (this.$refs.importUpload) {
+                    this.$refs.importUpload.clearFiles();
+                }
+            },
+            async importConnections() {
+                if (!this.importFileContent) return;
+
+                this.importing = true;
+
+                try {
+                    const response = await this.$post('settings/import-connections', {
+                        import_data: this.importFileContent,
+                        mode: this.importMode
+                    });
+
+                    this.settings.connections = response.data.connections;
+                    this.settings.mappings = response.data.mappings;
+                    this.settings.misc = response.data.misc;
+
+                    this.$notify.success({
+                        title: this.$t('Imported'),
+                        message: response.data.message,
+                        offset: 19,
+                        duration: 5000
+                    });
+
+                    this.closeImportDialog();
+                } catch (error) {
+                    const message = error.response?.data?.message || error.message || this.$t('An error occurred while importing connections.');
+                    this.$notify.error({
+                        title: this.$t('Import Failed'),
+                        message: message,
+                        offset: 19,
+                        duration: 5000
+                    });
+                } finally {
+                    this.importing = false;
+                }
             }
         },
         computed: {

--- a/resources/admin/Modules/Settings/Connections.vue
+++ b/resources/admin/Modules/Settings/Connections.vue
@@ -116,22 +116,14 @@
                 <p style="margin-bottom: 15px; color: #666;">
                     {{ $t('Select a JSON file exported from another FluentSMTP installation. The connections will be imported and merged with your existing ones.') }}
                 </p>
-                <el-upload
-                    ref="importUpload"
-                    :auto-upload="false"
-                    :on-change="onImportFileChange"
-                    :on-remove="onImportFileRemove"
-                    accept=".json"
-                    :limit="1"
-                    action="#"
-                >
-                    <el-button size="small" type="primary">
+                <div>
+                    <el-button size="small" type="primary" @click="selectImportFile">
                         <i class="el-icon-document"></i> {{ $t('Select JSON File') }}
                     </el-button>
-                    <div slot="tip" class="el-upload__tip" style="color: #999;">
+                    <div style="color: #999; font-size: 12px; line-height: 1; margin-top: 10px;">
                         {{ $t('Only .json files are accepted') }}
                     </div>
-                </el-upload>
+                </div>
 
                 <div v-if="importPreview" style="margin-top: 20px; padding: 15px; background: #f9f9f9; border-radius: 4px;">
                     <p style="font-weight: 600; margin-bottom: 10px;">
@@ -165,7 +157,6 @@
 
 <script type="text/babel">
     import Confirm from '@/Pieces/Confirm';
-    import isEmpty from 'lodash/isEmpty';
     import GeneralSettings from './_GeneralSettings'
 
     import ConnectionDetails from './ConnectionDetails'
@@ -193,15 +184,6 @@
                 const settings = await this.$get('settings');
                 this.settings.mappings = settings.data.settings.mappings;
                 this.settings.connections = settings.data.settings.connections;
-
-                if (isEmpty(this.settings.connections)) {
-                    this.$router.push({
-                        name: 'dashboard',
-                        query: {
-                            is_redirect: 'yes'
-                        }
-                    });
-                }
             },
             addConnection() {
                 this.$router.push({ name: 'connection' });
@@ -260,7 +242,17 @@
                     });
                 }
             },
-            onImportFileChange(file) {
+            selectImportFile() {
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = '.json';
+                input.addEventListener('change', this.onImportFileChange);
+                input.click();
+            },
+            onImportFileChange(event) {
+                const file = event.target.files[0];
+                if (!file) return;
+
                 const reader = new FileReader();
                 reader.onload = (e) => {
                     try {
@@ -287,7 +279,7 @@
                         this.importPreview = null;
                     }
                 };
-                reader.readAsText(file.raw);
+                reader.readAsText(file);
             },
             onImportFileRemove() {
                 this.importFileContent = null;
@@ -299,9 +291,6 @@
                 this.importPreview = null;
                 this.importing = false;
                 this.importMode = 'merge';
-                if (this.$refs.importUpload) {
-                    this.$refs.importUpload.clearFiles();
-                }
             },
             async importConnections() {
                 if (!this.importFileContent) return;
@@ -309,9 +298,15 @@
                 this.importing = true;
 
                 try {
-                    const response = await this.$post('settings/import-connections', {
-                        import_data: this.importFileContent,
-                        mode: this.importMode
+                    const response = await jQuery.ajax({
+                        url: window.ajaxurl + '?action=' + window.FluentMail.appVars.slug + '-post-settings/import-connections&nonce=' + window.FluentMail.appVars.nonce,
+                        type: 'POST',
+                        contentType: 'application/json',
+                        data: JSON.stringify({
+                            import_data: this.importFileContent,
+                            mode: this.importMode
+                        }),
+                        processData: false
                     });
 
                     this.settings.connections = response.data.connections;
@@ -327,7 +322,7 @@
 
                     this.closeImportDialog();
                 } catch (error) {
-                    const message = error.response?.data?.message || error.message || this.$t('An error occurred while importing connections.');
+                    const message = error.responseJSON?.data?.message || error.statusText || this.$t('An error occurred while importing connections.');
                     this.$notify.error({
                         title: this.$t('Import Failed'),
                         message: message,


### PR DESCRIPTION
This PR adds the ability to import and export mail connections as JSON, making it easy to transfer FluentSMTP configuration between sites.

### Changes

**PHP Backend:**
- Added `GET settings/export-connections` endpoint — Exports all connections + mappings as JSON with metadata (version, date, source URL)
- Added `POST settings/import-connections` endpoint — Accepts JSON file, validates providers exist, merges or replaces into existing settings

**Vue Frontend:**
- Export button in connections header — Downloads `fluent-smtp-connections-{sitename}.json`
- Import dialog with file picker, preview of connections, and merge/replace mode selector

### How to test
1. Go to Settings → Email Connections
2. Click **Export** to download your connections as JSON
3. Click **Import** to upload a JSON file from another installation
4. Choose between **Merge** (add/overwrite individual connections) or **Replace** (replace all existing connections)

@techjewel please review