### PR TITLE
feat(logs): pick recipient on resend

### DIFF
--- a/app/Http/Controllers/LoggerController.php
+++ b/app/Http/Controllers/LoggerController.php
@@ -63,10 +63,29 @@ class LoggerController extends Controller
                 ], $response->get_error_code());
             });
 
-            if ($email = $logger->resendEmailFromLog($request->get('id'), $request->get('type'))) {
+            $recipients = $this->sanitizeRecipients($request->get('recipients'));
+
+            $resentEmail = $logger->resendEmailFromLog(
+                $request->get('id'),
+                $request->get('type'),
+                $recipients
+            );
+
+            if ($resentEmail) {
+                $message = __('Email sent successfully.', 'fluent-smtp');
+
+                if (!empty($recipients)) {
+                    $message = sprintf(
+                        /* translators: %s: comma separated list of email addresses */
+                        __('Email sent successfully to %s.', 'fluent-smtp'),
+                        implode(', ', $recipients)
+                    );
+                }
+
                 return $this->sendSuccess([
-                    'email' => $email,
-                    'message' => __('Email sent successfully.', 'fluent-smtp')
+                    'email'      => $resentEmail,
+                    'recipients' => $recipients,
+                    'message'    => $message
                 ]);
             }
 
@@ -77,6 +96,55 @@ class LoggerController extends Controller
                 'message' => $e->getMessage()
             ], $e->getCode());
         }
+    }
+
+    /**
+     * Sanitize and validate a list of recipient email addresses coming
+     * from the resend dialog. Returns an array of valid email addresses
+     * or an empty array when none are provided / valid.
+     *
+     * @param  mixed $rawRecipients
+     * @return array<int, string>
+     * @throws \Exception When an invalid email address is supplied.
+     */
+    protected function sanitizeRecipients($rawRecipients)
+    {
+        if (empty($rawRecipients)) {
+            return [];
+        }
+
+        if (is_string($rawRecipients)) {
+            $rawRecipients = preg_split('/[\s,;]+/', $rawRecipients);
+        }
+
+        if (!is_array($rawRecipients)) {
+            return [];
+        }
+
+        $recipients = [];
+
+        foreach ($rawRecipients as $recipient) {
+            $recipient = sanitize_email(trim((string) $recipient));
+
+            if ($recipient === '') {
+                continue;
+            }
+
+            if (!is_email($recipient)) {
+                throw new \Exception(
+                    sprintf(
+                        /* translators: %s: email address */
+                        esc_html__('Invalid email address: %s', 'fluent-smtp'),
+                        esc_html($recipient)
+                    ),
+                    422
+                );
+            }
+
+            $recipients[] = $recipient;
+        }
+
+        return array_values(array_unique($recipients));
     }
 
     public function retryBulk(Request $request, Logger $logger)

--- a/app/Models/Logger.php
+++ b/app/Models/Logger.php
@@ -329,7 +329,7 @@ class Logger extends Model
         return (array)$row;
     }
 
-    public function resendEmailFromLog($id, $type = 'retry')
+    public function resendEmailFromLog($id, $type = 'retry', $recipients = [])
     {
         $email = $this->find($id);
 
@@ -358,9 +358,18 @@ class Logger extends Model
             }
         }
 
+        // When custom recipients are provided, drop cc/bcc headers so the email
+        // is only delivered to the requested address(es).
+        $hasCustomRecipients = !empty($recipients) && is_array($recipients);
+        $skipHeaderKeys = $hasCustomRecipients ? ['cc', 'bcc'] : [];
+
         $headers = [];
 
         foreach ($email['headers'] as $key => $value) {
+
+            if (in_array(strtolower((string) $key), $skipHeaderKeys, true)) {
+                continue;
+            }
 
             if($key == 'content-type' && $value == 'multipart/alternative') {
                 $value = 'text/html';
@@ -389,12 +398,16 @@ class Logger extends Model
             'From: ' . $email['from']
         ]);
 
-        $to = [];
-        foreach ($email['to'] as $recipient) {
-            if (isset($recipient['name'])) {
-                $to[] = $recipient['name'] . ' <' . $recipient['email'] . '>';
-            } else {
-                $to[] = $recipient['email'];
+        if ($hasCustomRecipients) {
+            $to = array_values($recipients);
+        } else {
+            $to = [];
+            foreach ($email['to'] as $recipient) {
+                if (isset($recipient['name'])) {
+                    $to[] = $recipient['name'] . ' <' . $recipient['email'] . '>';
+                } else {
+                    $to[] = $recipient['email'];
+                }
             }
         }
 

--- a/resources/admin/Modules/Logger/LogViewer.vue
+++ b/resources/admin/Modules/Logger/LogViewer.vue
@@ -34,7 +34,7 @@
                                     size="mini"
                                     type="success"
                                     icon="el-icon-refresh-right"
-                                    @click="handleRetry(log, 'resend')"
+                                    @click="handleResendClick"
                                     v-if="log.status == 'sent'"
                                 >
                                     {{ $t('Resend') }}
@@ -150,23 +150,37 @@
                 </el-row>
             </div>
         </el-dialog>
+
+        <ResendDialog
+            v-model="resendDialog.visible"
+            :log="resendDialog.log"
+            :resending="resendDialog.resending"
+            @confirm="handleResendConfirm"
+            @closed="handleResendDialogClosed"
+        />
     </div>
 </template>
 
 <script>
 import EmailbodyContainer from './EmailbodyContainer';
+import ResendDialog from './ResendDialog';
 
 export default {
     name: 'LogViewer',
     props: ['logViewerProps'],
-    components: {EmailbodyContainer},
+    components: {EmailbodyContainer, ResendDialog},
     data() {
         return {
             activeName: 'email_body',
             loading: false,
             next: false,
             prev: false,
-            retrying: false
+            retrying: false,
+            resendDialog: {
+                visible: false,
+                log: null,
+                resending: false
+            }
         };
     },
     methods: {
@@ -218,16 +232,28 @@ export default {
             name = name[0].replace(/\\/g, '/');
             return name.split('/').pop();
         },
-        handleRetry(log, type) {
+        handleRetry(log, type, recipients = null) {
             this.retrying = true;
-            this.$post('logs/retry', {
+
+            const payload = {
                 id: log.id,
                 type: type
-            }).then(res => {
+            };
+
+            if (recipients && recipients.length) {
+                payload.recipients = recipients;
+            }
+
+            return this.$post('logs/retry', payload).then(res => {
                 this.logViewerProps.retries = res.data.email.retries;
                 this.logViewerProps.log.status = res.data.email.status;
                 this.logViewerProps.log.updated_at = res.data.email.updated_at;
                 this.logViewerProps.log.resent_count = res.data.email.resent_count;
+                this.$notify.success({
+                    offset: 19,
+                    title: 'Great!',
+                    message: res.data.message
+                });
             }).fail(error => {
                 this.$notify.error({
                     offset: 19,
@@ -237,6 +263,29 @@ export default {
             }).always(() => {
                 this.retrying = false;
             });
+        },
+        handleResendClick() {
+            this.resendDialog.log = this.log;
+            this.resendDialog.resending = false;
+            this.resendDialog.visible = true;
+        },
+        handleResendConfirm(payload) {
+            const log = this.resendDialog.log;
+            if (!log) {
+                return;
+            }
+
+            const recipients = payload.target === 'original' ? null : payload.recipients;
+
+            this.resendDialog.resending = true;
+            this.handleRetry(log, 'resend', recipients).always(() => {
+                this.resendDialog.resending = false;
+                this.resendDialog.visible = false;
+            });
+        },
+        handleResendDialogClosed() {
+            this.resendDialog.log = null;
+            this.resendDialog.resending = false;
         },
         sanitize(html) {
             return window.DOMPurify.sanitize(html);

--- a/resources/admin/Modules/Logger/Logs.vue
+++ b/resources/admin/Modules/Logger/Logs.vue
@@ -91,7 +91,7 @@
                                 size="mini"
                                 type="success"
                                 icon="el-icon-refresh-right"
-                                @click="handleRetry(scope.row, 'resend')"
+                                @click="handleResendClick(scope.row)"
                                 v-if="scope.row.status == 'sent'"
                             >
                                 {{ $t('Resend') }}
@@ -137,6 +137,14 @@
             <el-skeleton :animated="true" v-else class="fss_content" :rows="15"></el-skeleton>
 
             <LogViewer :logViewerProps="logViewerProps"/>
+
+            <ResendDialog
+                v-model="resendDialog.visible"
+                :log="resendDialog.log"
+                :resending="resendDialog.resending"
+                @confirm="handleResendConfirm"
+                @closed="handleResendDialogClosed"
+            />
         </div>
     </div>
 </template>
@@ -147,6 +155,7 @@ import Pagination from '@/Pieces/Pagination';
 import LogFilter from './LogFilter';
 import LogViewer from './LogViewer';
 import LogBulkAction from './BulkAction';
+import ResendDialog from './ResendDialog';
 import isEmpty from 'lodash/isEmpty'
 
 export default {
@@ -156,7 +165,8 @@ export default {
         Pagination,
         LogFilter,
         LogViewer,
-        LogBulkAction
+        LogBulkAction,
+        ResendDialog
     },
     data() {
         return {
@@ -168,6 +178,11 @@ export default {
             logViewerProps: {
                 log: null,
                 dialogVisible: false
+            },
+            resendDialog: {
+                visible: false,
+                log: null,
+                resending: false
             },
             pagination: {
                 total: 0,
@@ -277,12 +292,19 @@ export default {
                 return this.handleResendBulk(this.selectedLogs);
             }
         },
-        handleRetry(row, type) {
+        handleRetry(row, type, recipients = null) {
             this.loading = true;
-            this.$post('logs/retry', {
+
+            const payload = {
                 id: row.id,
                 type: type
-            }).then(res => {
+            };
+
+            if (recipients && recipients.length) {
+                payload.recipients = recipients;
+            }
+
+            return this.$post('logs/retry', payload).then(res => {
                 if (!res.data.email) {
                     this.$notify.error({
                         offset: 19,
@@ -300,15 +322,40 @@ export default {
                     title: 'Great!',
                     message: res.data.message
                 });
+                return true;
             }).fail(error => {
                 this.$notify.error({
                     offset: 19,
                     title: 'Oops!!',
                     message: error.responseJSON.data.message
                 });
+                return false;
             }).always(() => {
                 this.loading = false;
             });
+        },
+        handleResendClick(row) {
+            this.resendDialog.log = row;
+            this.resendDialog.resending = false;
+            this.resendDialog.visible = true;
+        },
+        handleResendConfirm(payload) {
+            const row = this.resendDialog.log;
+            if (!row) {
+                return;
+            }
+
+            const recipients = payload.target === 'original' ? null : payload.recipients;
+
+            this.resendDialog.resending = true;
+            this.handleRetry(row, 'resend', recipients).always(() => {
+                this.resendDialog.resending = false;
+                this.resendDialog.visible = false;
+            });
+        },
+        handleResendDialogClosed() {
+            this.resendDialog.log = null;
+            this.resendDialog.resending = false;
         },
         handleView(row) {
             this.logViewerProps.log = row;

--- a/resources/admin/Modules/Logger/ResendDialog.vue
+++ b/resources/admin/Modules/Logger/ResendDialog.vue
@@ -1,0 +1,231 @@
+<template>
+    <el-dialog
+        :title="$t('Resend Email')"
+        :visible.sync="visible"
+        @closed="handleClosed"
+        :close-on-click-modal="false"
+        append-to-body
+        width="480px"
+        custom-class="fss_resend_dialog"
+    >
+        <div v-if="log" v-loading="resending">
+            <p style="margin-top:0;">
+                <strong>{{ $t('Subject') }}:</strong> {{ log.subject }}
+            </p>
+            <p>
+                <strong>{{ $t('Original recipient(s)') }}:</strong>
+                <span>{{ formatOriginalRecipients(log.to) }}</span>
+            </p>
+
+            <el-form
+                ref="form"
+                label-position="top"
+                :model="form"
+                @submit.native.prevent
+            >
+                <el-form-item :label="$t('Send this email to:')">
+                    <el-radio-group v-model="form.target" style="display:block;">
+                        <el-radio
+                            label="original"
+                            style="display:block;margin:6px 0;"
+                        >{{ $t('Original recipient(s)') }}</el-radio>
+                        <el-radio
+                            label="self"
+                            style="display:block;margin:6px 0;"
+                        >{{ $t('My account email') }}
+                            <span v-if="appVars.user_email" style="color:#909399;">
+                                ({{ appVars.user_email }})
+                            </span>
+                        </el-radio>
+                        <el-radio
+                            label="custom"
+                            style="display:block;margin:6px 0;"
+                        >{{ $t('A different email address') }}</el-radio>
+                    </el-radio-group>
+                </el-form-item>
+
+                <el-form-item v-if="form.target === 'custom'">
+                    <el-input
+                        ref="customInput"
+                        type="text"
+                        v-model="form.customEmail"
+                        :placeholder="$t('e.g. you@example.com')"
+                        @keyup.enter.native="handleConfirm"
+                        autocomplete="off"
+                        data-bwignore
+                        data-lpignore="true"
+                        data-1p-ignore
+                    />
+                    <span class="small-help-text" style="display:block;margin-top:4px;">
+                        {{ $t('Separate multiple email addresses with commas.') }}
+                    </span>
+                </el-form-item>
+            </el-form>
+        </div>
+
+        <span slot="footer" class="dialog-footer">
+            <el-button size="small" @click="visible = false" :disabled="resending">
+                {{ $t('Cancel') }}
+            </el-button>
+            <el-button
+                type="success"
+                size="small"
+                icon="el-icon-refresh-right"
+                :loading="resending"
+                @click="handleConfirm"
+            >
+                {{ $t('Resend') }}
+            </el-button>
+        </span>
+    </el-dialog>
+</template>
+
+<script>
+export default {
+    name: 'ResendDialog',
+    props: {
+        value: {
+            type: Boolean,
+            default: false
+        },
+        log: {
+            type: Object,
+            default: null
+        },
+        resending: {
+            type: Boolean,
+            default: false
+        }
+    },
+    data() {
+        return {
+            form: {
+                target: 'original',
+                customEmail: ''
+            }
+        };
+    },
+    computed: {
+        visible: {
+            get() {
+                return this.value;
+            },
+            set(val) {
+                this.$emit('input', val);
+            }
+        }
+    },
+    watch: {
+        value(newVal) {
+            if (newVal) {
+                this.form.target = 'original';
+                this.form.customEmail = '';
+            }
+        },
+        'form.target'(newVal) {
+            if (newVal === 'custom') {
+                this.$nextTick(() => {
+                    if (this.$refs.customInput) {
+                        this.$refs.customInput.focus();
+                    }
+                });
+            }
+        }
+    },
+    methods: {
+        handleClosed() {
+            this.$emit('closed');
+        },
+        handleConfirm() {
+            if (this.resending) {
+                return;
+            }
+
+            const payload = { target: this.form.target };
+
+            if (this.form.target === 'self') {
+                const userEmail = this.appVars && this.appVars.user_email
+                    ? this.appVars.user_email.trim()
+                    : '';
+
+                if (!userEmail) {
+                    this.$notify.error({
+                        offset: 19,
+                        title: this.$t('Oops!'),
+                        message: this.$t('No account email is available for the current user.')
+                    });
+                    return;
+                }
+
+                payload.recipients = [userEmail];
+            }
+
+            if (this.form.target === 'custom') {
+                const parsed = this.parseEmails(this.form.customEmail);
+
+                if (!parsed.valid.length && !parsed.invalid.length) {
+                    this.$notify.error({
+                        offset: 19,
+                        title: this.$t('Oops!'),
+                        message: this.$t('Please enter a valid email address')
+                    });
+                    return;
+                }
+
+                if (parsed.invalid.length) {
+                    this.$notify.error({
+                        offset: 19,
+                        title: this.$t('Oops!'),
+                        message: this.$t('Please enter a valid email address') + ': ' + parsed.invalid.join(', ')
+                    });
+                    return;
+                }
+
+                payload.recipients = parsed.valid;
+            }
+
+            this.$emit('confirm', payload);
+        },
+        parseEmails(input) {
+            const tokens = (input || '')
+                .split(/[\s,;]+/)
+                .map(t => t.trim())
+                .filter(Boolean);
+
+            const valid = [];
+            const invalid = [];
+            const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+            tokens.forEach(token => {
+                if (re.test(token)) {
+                    valid.push(token);
+                } else {
+                    invalid.push(token);
+                }
+            });
+
+            return { valid, invalid };
+        },
+        formatOriginalRecipients(to) {
+            if (!to) {
+                return '—';
+            }
+
+            if (typeof to === 'string') {
+                return to;
+            }
+
+            if (!Array.isArray(to)) {
+                return String(to);
+            }
+
+            return to.map(val => {
+                if (val && val.name) {
+                    return `${val.name} <${val.email}>`;
+                }
+                return val && val.email ? val.email : '';
+            }).join(', ');
+        }
+    }
+};
+</script>


### PR DESCRIPTION
## Summary

Resend from Email Logs now asks where the email should go: the original recipient(s) (default), the current admin's email, or one or more custom addresses. This builds on #394 (same approach and dialog) and adds one fix on top: the original recipients in the dialog are rendered as plain text instead of `v-html`, since the stored `to` field is untrusted data and `v-html` on it is a stored XSS risk.

Fixes #395

## Changes

### app/Models/Logger.php

**Before:**
```php
public function resendEmailFromLog($id, $type = 'retry')
```

**After:**
```php
public function resendEmailFromLog($id, $type = 'retry', $recipients = [])
```

**Why:** When `$recipients` is a non-empty array it replaces the `to` list and `cc`/`bcc` headers are stripped, so the email only goes to the requested addresses. When it is empty the method behaves exactly as before, so bulk resend and any programmatic callers are untouched. The stored `to` field on the log row is never modified; only `status`, `updated_at` and `resent_count` advance.

### app/Http/Controllers/LoggerController.php

`retry()` now reads an optional `recipients` param and validates it with a new `sanitizeRecipients()` helper: each address goes through `sanitize_email()` + `is_email()`, bad input throws a translated 422. The success message names the actual recipients when custom ones are used.

**Why:** client-side validation is only a convenience; the server is the real gate.

### resources/admin/Modules/Logger/ResendDialog.vue (new)

Dialog with three radio options. The custom option reveals a comma-separated email input, Enter submits, and the form resets every time the dialog opens.

### resources/admin/Modules/Logger/Logs.vue and LogViewer.vue

The row Resend button and the viewer Resend button now open the dialog. Bulk resend and the Retry button on failed rows keep their one-click behavior.

## Testing

There is no automated test suite in this repo (no phpunit config, no test scripts). Tested manually on a live install:

**Test 1: Resend to original (default)**
1. Email Logs, click Resend on a row
2. Keep "Original recipient(s)" selected, click Resend

Result: original recipient receives the email, `resent_count` increments.

**Test 2: Resend to my account or custom addresses**
1. Pick "My account email", or enter `a@example.com, b@example.com` in the custom field

Result: only those addresses receive the email, the original recipient does not.

**Test 3: Invalid custom address**
1. Enter `bogus-no-at, valid@example.com`

Result: error notification naming the bad address, nothing is sent.

**Test 4: Backward compatibility**
1. Bulk Resend and Retry on a failed row

Result: one-click to the original recipients, unchanged.

Checks run: `php -l` clean on both changed PHP files, PHPStan reports no new findings on the changed files (the 41 existing errors are all in `includes/Support/*`), production webpack build compiled successfully.

## Screen recording

https://github.com/user-attachments/assets/60e84d0a-7837-487b-aba6-9939233f1137

