### PR TITLE
Smtp oauth and log index

### DIFF
--- a/app/Hooks/Handlers/ActionsRegistrar.php
+++ b/app/Hooks/Handlers/ActionsRegistrar.php
@@ -55,6 +55,22 @@ class ActionsRegistrar
 
         // SMTP connection reuse across FluentCRM bulk sending sessions.
         (new BulkSendSessionHandler())->register();
+
+        $this->registerCliCommands();
+    }
+
+    /**
+     * Register the `wp fluent-smtp` commands.
+     *
+     * @return void
+     */
+    protected function registerCliCommands()
+    {
+        if (!defined('WP_CLI') || !WP_CLI || !class_exists('\WP_CLI')) {
+            return;
+        }
+
+        \WP_CLI::add_command('fluent-smtp', '\FluentMail\App\Services\CliHandler');
     }
 
     /**

--- a/app/Hooks/Handlers/SchedulerHandler.php
+++ b/app/Hooks/Handlers/SchedulerHandler.php
@@ -4,6 +4,7 @@ namespace FluentMail\App\Hooks\Handlers;
 
 use FluentMail\App\Models\Logger;
 use FluentMail\App\Models\Settings;
+use FluentMail\App\Services\ConnectionHealth;
 use FluentMail\App\Services\NotificationHelper;
 use FluentMail\App\Services\Notification\Manager as NotificationManager;
 use FluentMail\Includes\Support\Arr;
@@ -18,14 +19,29 @@ class SchedulerHandler
         add_filter('fluentmail_email_sending_failed', array($this, 'maybeHandleFallbackConnection'), 10, 4);
 
         add_action('fluentsmtp_renew_gmail_token', array($this, 'renewGmailToken'));
+        add_action('fluentsmtp_renew_outlook_token', array($this, 'renewOutlookToken'));
 
         add_action('fluentmail_email_sending_failed_no_fallback', array($this, 'maybeSendNotification'), 10, 3);
+
+        add_action('fluentmail_connection_health_failed', array($this, 'notifyUnhealthyConnections'));
     }
 
     public function handleScheduledJobs()
     {
         $this->deleteOldEmails();
         $this->sendDailyDigest();
+        $this->checkConnectionHealth();
+    }
+
+    /**
+     * Doubles as the safety net for token renewal. The single events that keep
+     * the OAuth tokens fresh are only ever armed by a successful renewal, so a
+     * single failed one used to end the chain silently - this daily pass picks
+     * it back up.
+     */
+    private function checkConnectionHealth()
+    {
+        (new ConnectionHealth())->checkAll();
     }
 
     private function deleteOldEmails()
@@ -215,6 +231,106 @@ class SchedulerHandler
         }
     }
 
+    /**
+     * Announce connections that have just started failing their health check,
+     * over whichever channels the site has already set up.
+     *
+     * @param array $failing
+     * @return void
+     */
+    public function notifyUnhealthyConnections($failing)
+    {
+        if (!$failing) {
+            return;
+        }
+
+        $notificationManager = new NotificationManager();
+        $channels = $notificationManager->getActiveChannels();
+
+        if (!$channels) {
+            return;
+        }
+
+        foreach ($failing as $connection) {
+            $provider = Arr::get($connection, 'provider');
+            $errorMessage = Arr::get($connection, 'message');
+
+            $message = sprintf(
+            /* translators: 1: site name, 2: provider name, 3: sender email, 4: error message */
+                __('FluentSMTP on %1$s cannot use the %2$s connection for %3$s any more: %4$s', 'fluent-smtp'),
+                get_bloginfo('name'),
+                $provider,
+                Arr::get($connection, 'sender_email'),
+                $errorMessage
+            );
+
+            foreach ($channels as $channel) {
+                $driver = $channel['driver'];
+                $channelSettings = Arr::get($channel, 'settings', []);
+
+                if ($driver == 'telegram') {
+                    NotificationHelper::sendFailedNotificationTele([
+                        'token_id'      => Arr::get($channelSettings, 'token'),
+                        'provider'      => $provider,
+                        'error_message' => $errorMessage
+                    ]);
+                    continue;
+                }
+
+                if ($driver == 'slack') {
+                    NotificationHelper::sendSlackMessage($message, Arr::get($channelSettings, 'webhook_url'), false);
+                    continue;
+                }
+
+                if ($driver == 'discord') {
+                    NotificationHelper::sendDiscordMessage($message, Arr::get($channelSettings, 'webhook_url'), false);
+                    continue;
+                }
+
+                if ($driver == 'pushover') {
+                    NotificationHelper::sendPushoverMessage(
+                        $message,
+                        Arr::get($channelSettings, 'api_token'),
+                        Arr::get($channelSettings, 'user_key'),
+                        false,
+                        1
+                    );
+                    continue;
+                }
+            }
+        }
+    }
+
+    public function renewOutlookToken()
+    {
+        $settings = fluentMailGetSettings();
+
+        if (!$settings) {
+            return;
+        }
+
+        $connections = Arr::get($settings, 'connections', []);
+
+        foreach ($connections as $connection) {
+            $providerSettings = Arr::get($connection, 'provider_settings', []);
+
+            if (Arr::get($providerSettings, 'provider') != 'outlook') {
+                continue;
+            }
+
+            if (empty($providerSettings['refresh_token'])) {
+                continue;
+            }
+
+            if ((Arr::get($providerSettings, 'expire_stamp') - 480) >= time()) {
+                continue;
+            }
+
+            $handler = new \FluentMail\App\Services\Mailer\Providers\Outlook\Handler();
+            $handler->renewToken($providerSettings);
+        }
+    }
+
     public function callGmailApiForNewToken($settings)
     {
         if (Arr::get($settings, 'key_store') == 'wp_config') {
@@ -246,7 +362,16 @@ class SchedulerHandler
             $result = $this->saveNewGmailTokens($settings, $newTokens);
 
             if (!$result) {
-                return new \WP_Error('api_error', __('Failed to renew the token', 'fluent-smtp'));
+                // Google says why in error_description - usually that the
+                // grant was revoked or expired, which only re-authenticating
+                // fixes. Reporting "failed" alone leaves nothing to act on.
+                $errorDescription = Arr::get($newTokens, 'error_description');
+
+                if (!$errorDescription) {
+                    $errorDescription = __('Failed to renew the token with the Gmail API', 'fluent-smtp');
+                }
+
+                return new \WP_Error('api_error', $errorDescription);
             }
 
             return true;

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -3,6 +3,7 @@
 namespace FluentMail\App\Http\Controllers;
 
 use FluentMail\App\Models\Logger;
+use FluentMail\App\Services\ConnectionHealth;
 use FluentMail\App\Services\Mailer\Manager;
 use FluentMail\App\Services\Reporting;
 use FluentMail\Includes\Request\Request;
@@ -17,8 +18,9 @@ class DashboardController extends Controller
         $connections = $manager->getSettings('connections', []);
 
         return $this->send([
-            'stats'         => $logger->getStats(),
-            'settings_stat' => [
+            'stats'              => $logger->getStats(),
+            'unhealthy_settings' => array_values((new ConnectionHealth())->getFailing()),
+            'settings_stat'      => [
                 'connection_counts' => count($connections),
                 'active_senders'    => count($manager->getSettings('mappings', [])),
                 'auto_delete_days'  => $manager->getSettings('misc.log_saved_interval_days'),

--- a/app/Models/Logger.php
+++ b/app/Models/Logger.php
@@ -461,8 +461,37 @@ class Logger extends Model
         try {
 
             $date = gmdate('Y-m-d H:i:s', current_time('timestamp') - $days * DAY_IN_SECONDS);
-            $query = $this->db->prepare("DELETE FROM {$this->table} WHERE `created_at` < %s", $date);
-            return $this->db->query($query);
+
+            /*
+             * Deleted in batches rather than in one statement. A site that has
+             * been logging for months can have this cron pass hit hundreds of
+             * thousands of rows, and a single unbounded DELETE holds locks for
+             * the whole scan - long enough to time out and leave the backlog
+             * permanently uncleared, since the next run faces the same pile.
+             * Batches let each statement commit and release.
+             */
+            $batchSize = (int)apply_filters('fluentmail_log_delete_batch_size', 2000);
+            $batchSize = max(1, $batchSize);
+
+            $deleted = 0;
+
+            do {
+                $query = $this->db->prepare(
+                    "DELETE FROM {$this->table} WHERE `created_at` < %s LIMIT %d",
+                    $date,
+                    $batchSize
+                );
+
+                $result = $this->db->query($query);
+
+                if (!$result) {
+                    break;
+                }
+
+                $deleted += $result;
+            } while ($result >= $batchSize);
+
+            return $deleted;
 
         } catch (Exception $e) {
             if (wp_get_environment_type() != 'production') {

--- a/app/Services/CliHandler.php
+++ b/app/Services/CliHandler.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace FluentMail\App\Services;
+
+use FluentMail\App\Models\Logger;
+use FluentMail\App\Models\Settings;
+use FluentMail\Includes\Support\Arr;
+
+/**
+ * WP-CLI commands for FluentSMTP.
+ *
+ * These matter most exactly when the admin UI is not an option: a broken
+ * connection on a site whose login emails are the thing that stopped working,
+ * a staging box behind HTTP auth, or a deploy script that wants to assert the
+ * mail path still works before it hands over.
+ */
+class CliHandler
+{
+    /**
+     * Send a test email through the active connection.
+     *
+     * ## OPTIONS
+     *
+     * [--to=<email>]
+     * : Recipient. Defaults to the site admin email.
+     *
+     * [--from=<email>]
+     * : Sender to route through. Defaults to the default connection.
+     *
+     * [--text]
+     * : Send a plain text email instead of HTML.
+     *
+     * ## EXAMPLES
+     *
+     *     wp fluent-smtp test
+     *     wp fluent-smtp test --to=me@example.com --text
+     *
+     * @when after_wp_load
+     */
+    public function test($args, $assocArgs)
+    {
+        $to = Arr::get($assocArgs, 'to', get_option('admin_email'));
+
+        if (!is_email($to)) {
+            \WP_CLI::error(sprintf('%s is not a valid email address.', $to));
+        }
+
+        $data = [
+            'email'  => $to,
+            'from'   => Arr::get($assocArgs, 'from', ''),
+            'isHtml' => isset($assocArgs['text']) ? 'false' : 'true'
+        ];
+
+        if (!defined('FLUENTMAIL_EMAIL_TESTING')) {
+            define('FLUENTMAIL_EMAIL_TESTING', true);
+        }
+
+        $error = '';
+
+        // wp_mail() reports a delivery failure through this action rather than
+        // its return value, so the reason has to be caught as it goes past.
+        add_action('wp_mail_failed', function ($wpError) use (&$error) {
+            $error = $wpError->get_error_message();
+        });
+
+        $settings = new Settings();
+
+        $startedAt = microtime(true);
+
+        try {
+            $result = $settings->sendTestEmail($data, $settings->get());
+        } catch (\Throwable $e) {
+            \WP_CLI::error($e->getMessage());
+            return;
+        }
+
+        $seconds = round(microtime(true) - $startedAt, 3);
+
+        if ($error) {
+            \WP_CLI::error(sprintf('Sending failed after %ss: %s', $seconds, $error));
+            return;
+        }
+
+        if (!$result) {
+            \WP_CLI::error(sprintf('Sending failed after %ss for an unreported reason.', $seconds));
+            return;
+        }
+
+        \WP_CLI::success(sprintf('Test email handed to the provider for %s in %ss.', $to, $seconds));
+    }
+
+    /**
+     * Check every configured connection and report the ones that are broken.
+     *
+     * ## OPTIONS
+     *
+     * [--format=<format>]
+     * : Render output in a particular format. Accepts table, csv, json, yaml.
+     * ---
+     * default: table
+     * ---
+     *
+     * ## EXAMPLES
+     *
+     *     wp fluent-smtp health
+     *     wp fluent-smtp health --format=json
+     *
+     * @when after_wp_load
+     */
+    public function health($args, $assocArgs)
+    {
+        $report = (new ConnectionHealth())->checkAll();
+
+        if (!$report) {
+            \WP_CLI::warning('No connections are configured.');
+            return;
+        }
+
+        $rows = [];
+
+        foreach ($report as $item) {
+            $rows[] = [
+                'sender'   => Arr::get($item, 'sender_email'),
+                'provider' => Arr::get($item, 'provider'),
+                'status'   => Arr::get($item, 'status'),
+                'message'  => Arr::get($item, 'message')
+            ];
+        }
+
+        \WP_CLI\Utils\format_items(
+            Arr::get($assocArgs, 'format', 'table'),
+            $rows,
+            ['sender', 'provider', 'status', 'message']
+        );
+
+        $failed = count(array_filter($rows, function ($row) {
+            return $row['status'] === ConnectionHealth::STATUS_ERROR;
+        }));
+
+        if ($failed) {
+            // A non-zero exit lets a deploy or monitoring script gate on this.
+            \WP_CLI::error(sprintf('%d of %d connection(s) need attention.', $failed, count($rows)));
+        }
+
+        \WP_CLI::success(sprintf('All %d connection(s) are healthy.', count($rows)));
+    }
+
+    /**
+     * Show sending stats from the email log.
+     *
+     * ## EXAMPLES
+     *
+     *     wp fluent-smtp stats
+     *
+     * @when after_wp_load
+     */
+    public function stats($args, $assocArgs)
+    {
+        $stats = (new Logger())->getStats();
+
+        \WP_CLI\Utils\format_items(
+            Arr::get($assocArgs, 'format', 'table'),
+            [
+                ['metric' => 'sent', 'count' => Arr::get($stats, 'sent', 0)],
+                ['metric' => 'failed', 'count' => Arr::get($stats, 'failed', 0)]
+            ],
+            ['metric', 'count']
+        );
+    }
+
+    /**
+     * Delete logged emails older than the retention window.
+     *
+     * ## OPTIONS
+     *
+     * [--days=<days>]
+     * : Delete logs older than this many days. Defaults to the configured
+     * retention setting.
+     *
+     * [--yes]
+     * : Skip the confirmation prompt.
+     *
+     * ## EXAMPLES
+     *
+     *     wp fluent-smtp prune-logs
+     *     wp fluent-smtp prune-logs --days=30 --yes
+     *
+     * @subcommand prune-logs
+     * @when after_wp_load
+     */
+    public function prune_logs($args, $assocArgs)
+    {
+        $days = Arr::get($assocArgs, 'days');
+
+        if ($days === null) {
+            $days = Arr::get(fluentMailGetSettings(), 'misc.log_saved_interval_days');
+        }
+
+        $days = (int)$days;
+
+        if ($days < 1) {
+            \WP_CLI::error('Provide a positive --days value, or configure a log retention period first.');
+            return;
+        }
+
+        \WP_CLI::confirm(
+            sprintf('Permanently delete every logged email older than %d day(s)?', $days),
+            $assocArgs
+        );
+
+        $deleted = (new Logger())->deleteLogsOlderThan($days);
+
+        \WP_CLI::success(sprintf('Deleted %d log entr%s.', (int)$deleted, $deleted == 1 ? 'y' : 'ies'));
+    }
+}

--- a/app/Services/ConnectionHealth.php
+++ b/app/Services/ConnectionHealth.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace FluentMail\App\Services;
+
+use FluentMail\App\Services\Mailer\Providers\Factory;
+use FluentMail\Includes\Support\Arr;
+
+/**
+ * Periodic health check for the configured connections.
+ *
+ * The failure this exists for is the silent one: an OAuth refresh token that
+ * ages out while the site is quiet, or an API key removed from wp-config.php
+ * months after it was set. Nothing surfaces either until the first email that
+ * needed to go out does not, and by then the send is already lost.
+ */
+class ConnectionHealth
+{
+    const OPTION_KEY = '_fluentsmtp_connection_health';
+
+    const STATUS_HEALTHY = 'healthy';
+    const STATUS_ERROR = 'error';
+
+    /**
+     * Run a check across every configured connection and store the outcome.
+     *
+     * @return array keyed by connection unique key
+     */
+    public function checkAll()
+    {
+        $settings = fluentMailGetSettings();
+        $connections = Arr::get($settings, 'connections', []);
+
+        $previous = $this->getReport();
+        $report = [];
+
+        foreach ($connections as $key => $connection) {
+            $providerSettings = Arr::get($connection, 'provider_settings', []);
+
+            if (!$providerSettings) {
+                continue;
+            }
+
+            $result = $this->checkConnection($providerSettings);
+
+            $report[$key] = [
+                'sender_email' => Arr::get($providerSettings, 'sender_email'),
+                'provider'     => Arr::get($providerSettings, 'provider'),
+                'status'       => $result['status'],
+                'message'      => $result['message'],
+                'checked_at'   => gmdate('Y-m-d H:i:s')
+            ];
+        }
+
+        update_option(self::OPTION_KEY, $report, false);
+
+        $this->notifyNewFailures($previous, $report);
+
+        return $report;
+    }
+
+    /**
+     * @return array
+     */
+    public function getReport()
+    {
+        $report = get_option(self::OPTION_KEY);
+
+        return is_array($report) ? $report : [];
+    }
+
+    /**
+     * Connections that are currently failing their check.
+     *
+     * @return array
+     */
+    public function getFailing()
+    {
+        return array_filter($this->getReport(), function ($item) {
+            return Arr::get($item, 'status') === self::STATUS_ERROR;
+        });
+    }
+
+    /**
+     * @param array $providerSettings
+     * @return array{status: string, message: string}
+     */
+    public function checkConnection($providerSettings)
+    {
+        $provider = Arr::get($providerSettings, 'provider');
+
+        try {
+            /*
+             * The OAuth providers are checked by actually renewing the token.
+             * That is the operation which silently rots, and it is the only way
+             * to learn that the grant is still good - a stored token that has
+             * not expired yet says nothing about whether it was revoked.
+             */
+            if ($provider == 'outlook') {
+                $result = (new \FluentMail\App\Services\Mailer\Providers\Outlook\Handler())
+                    ->renewToken($providerSettings);
+            } elseif ($provider == 'gmail') {
+                $result = (new \FluentMail\App\Hooks\Handlers\SchedulerHandler())
+                    ->callGmailApiForNewToken($providerSettings);
+            } else {
+                /*
+                 * Everything else gets a credential check rather than a live
+                 * API probe. A probe per provider per day would be better
+                 * signal, but it burns provider rate limits and each one needs
+                 * its own endpoint - so that is left to this filter.
+                 */
+                $result = apply_filters(
+                    'fluentmail_connection_health_probe',
+                    true,
+                    $providerSettings
+                );
+
+                if ($result === true) {
+                    $handler = fluentMail(Factory::class)->make($provider);
+                    $handler->validateProviderInformation($providerSettings);
+                }
+            }
+
+            if (is_wp_error($result)) {
+                return [
+                    'status'  => self::STATUS_ERROR,
+                    'message' => $result->get_error_message()
+                ];
+            }
+        } catch (\Exception $e) {
+            return [
+                'status'  => self::STATUS_ERROR,
+                'message' => $this->flattenMessage($e)
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'status'  => self::STATUS_ERROR,
+                'message' => $e->getMessage()
+            ];
+        }
+
+        return [
+            'status'  => self::STATUS_HEALTHY,
+            'message' => ''
+        ];
+    }
+
+    /**
+     * A ValidationException carries the useful part in its error bag rather
+     * than in the message, which is always "Unprocessable Entity".
+     *
+     * @param \Exception $e
+     * @return string
+     */
+    private function flattenMessage($e)
+    {
+        if (!method_exists($e, 'errors')) {
+            return $e->getMessage();
+        }
+
+        $messages = [];
+
+        foreach ((array)$e->errors() as $field => $fieldErrors) {
+            foreach ((array)$fieldErrors as $error) {
+                $messages[] = is_array($error) ? implode(' ', $error) : $error;
+            }
+        }
+
+        return $messages ? implode(' ', $messages) : $e->getMessage();
+    }
+
+    /**
+     * Only connections that have just started failing are announced. A
+     * connection that has been broken for a week should not re-notify daily.
+     *
+     * @param array $previous
+     * @param array $current
+     * @return void
+     */
+    private function notifyNewFailures($previous, $current)
+    {
+        $newlyFailing = [];
+
+        foreach ($current as $key => $item) {
+            if (Arr::get($item, 'status') !== self::STATUS_ERROR) {
+                continue;
+            }
+
+            if (Arr::get($previous, $key . '.status') === self::STATUS_ERROR) {
+                continue;
+            }
+
+            $newlyFailing[$key] = $item;
+        }
+
+        if (!$newlyFailing) {
+            return;
+        }
+
+        do_action('fluentmail_connection_health_failed', $newlyFailing);
+    }
+}

--- a/app/Services/Mailer/Providers/Factory.php
+++ b/app/Services/Mailer/Providers/Factory.php
@@ -26,20 +26,29 @@ class Factory
 
     public function get($email)
     {
-        if (!($conn = $this->settings->getConnection($email))) {
-            $conn = $this->getDefaultProvider();
-        }
-        
-        if ($conn) {
+        if ($conn = $this->settings->getConnection($email)) {
             $settings = array_merge($conn['provider_settings'], [
-                'title' => $conn['title']
+                'title' => isset($conn['title']) ? $conn['title'] : ''
             ]);
-            
+
             return $this->make(
                 $conn['provider_settings']['provider']
             )->setSettings($settings);
         }
-        
+
+        /*
+         * The two shapes differ. A stored connection is the wrapper
+         * {title, provider_settings}, but fluentMailDefaultConnection()
+         * returns the provider_settings payload itself. Unwrapping the
+         * default a second time - as this used to - reads a key that is not
+         * there and hands null to array_merge(), which is fatal. So the
+         * default is used as-is.
+         */
+        $default = $this->getDefaultProvider();
+
+        if ($default && !empty($default['provider'])) {
+            return $this->make($default['provider'])->setSettings($default);
+        }
 
         throw new InvalidArgumentException(
             esc_html__('There is no matching provider found by email: ', 'fluent-smtp') . $email // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped

--- a/app/Services/Mailer/Providers/Gmail/Handler.php
+++ b/app/Services/Mailer/Providers/Gmail/Handler.php
@@ -304,10 +304,26 @@ class Handler extends BaseHandler
             require_once FLUENTMAIL_PLUGIN_PATH . 'includes/libs/google-api-client/build/vendor/autoload.php';
         }
 
-        $client = $this->getApiClient($connection);
+        $tokenError = '';
 
-        if (is_wp_error($client)) {
-            return '<p style="color: red; text-align: center; font-size: 18px;">ERROR: ' . $connection->get_error_message() . '</p>';
+        try {
+            $client = $this->getApiClient($connection);
+
+            /*
+             * This read `$connection->get_error_message()` - a method call on
+             * the array parameter, which is a fatal Error rather than a
+             * catchable Exception. It fired exactly when someone opened this
+             * panel to find out why their Gmail connection had stopped
+             * working, so the one screen that could explain the failure was
+             * the one screen guaranteed to die on it.
+             */
+            if (is_wp_error($client)) {
+                $tokenError = $client->get_error_message();
+            }
+        } catch (\Exception $e) {
+            // The Google client throws on a rejected grant rather than
+            // returning an error, and nothing upstream catches it here.
+            $tokenError = $e->getMessage();
         }
 
         $info = fluentMailgetConnection($connection['sender_email']);
@@ -316,10 +332,12 @@ class Handler extends BaseHandler
 
         $extraRow = [
             'title'   => __('Token Validity', 'fluent-smtp'),
-            'content' => 'Valid (' . (int)(($connection['expire_stamp'] - time()) / 60) . 'minutes)'
+            'content' => 'Valid (' . (int)((Arr::get($connection, 'expire_stamp') - time()) / 60) . 'minutes)'
         ];
 
-        if (($connection['expire_stamp']) < time()) {
+        if ($tokenError) {
+            $extraRow['content'] = $tokenError;
+        } elseif (Arr::get($connection, 'expire_stamp') < time()) {
             $extraRow['content'] = __('Invalid. Please re-authenticate', 'fluent-smtp');
         }
 

--- a/app/Services/Mailer/Providers/Outlook/Handler.php
+++ b/app/Services/Mailer/Providers/Outlook/Handler.php
@@ -35,14 +35,43 @@ class Handler extends BaseHandler
 
     public function setSettings($settings)
     {
+        $this->settings = self::withResolvedKeys($settings);
+
+        return $this;
+    }
+
+    /**
+     * The client id/secret can live in wp-config.php instead of the database,
+     * in which case the stored connection carries empty values for both.
+     *
+     * @param array $settings
+     * @return array
+     */
+    private static function withResolvedKeys($settings)
+    {
         if (Arr::get($settings, 'key_store') == 'wp_config') {
             $settings['client_id'] = defined('FLUENTMAIL_OUTLOOK_CLIENT_ID') ? FLUENTMAIL_OUTLOOK_CLIENT_ID : '';
             $settings['client_secret'] = defined('FLUENTMAIL_OUTLOOK_CLIENT_SECRET') ? FLUENTMAIL_OUTLOOK_CLIENT_SECRET : '';
         }
 
-        $this->settings = $settings;
+        return $settings;
+    }
 
-        return $this;
+    /**
+     * Renew the access token for a connection outside of a send, so an idle
+     * site cannot let the refresh token age out unnoticed.
+     *
+     * @param array $connection provider_settings of the connection
+     * @return true|\WP_Error
+     */
+    public function renewToken($connection)
+    {
+        try {
+            $this->getAccessToken(self::withResolvedKeys($connection), true);
+            return true;
+        } catch (\Exception $e) {
+            return new \WP_Error('token_renew_failed', $e->getMessage());
+        }
     }
 
     private function sendViaApi()
@@ -140,38 +169,82 @@ class Handler extends BaseHandler
 
     private function saveNewTokens($existingData, $tokens)
     {
-        if (empty($tokens['access_token']) || empty($tokens['refresh_token'])) {
+        if (empty($tokens['access_token'])) {
             return false;
         }
 
         $senderEmail = $existingData['sender_email'];
 
         $existingData['access_token'] = $tokens['access_token'];
-        $existingData['refresh_token'] = $tokens['refresh_token'];
-        $existingData['expire_stamp'] = $tokens['expires_in'] + time();
+
+        /*
+         * A refresh response does not have to carry a new refresh token. When
+         * it does not, the one we already hold stays valid - so it is kept
+         * rather than overwritten. Bailing out here (as this used to) threw
+         * away a perfectly good access token as well, which left expire_stamp
+         * in the past and made every single send perform its own refresh. That
+         * eventually trips the identity server's throttling, and the
+         * connection looks dead for reasons nothing reports.
+         */
+        if (!empty($tokens['refresh_token'])) {
+            $existingData['refresh_token'] = $tokens['refresh_token'];
+        }
+
+        $expiresIn = !empty($tokens['expires_in']) ? (int)$tokens['expires_in'] : 3600;
+        $existingData['expire_stamp'] = $expiresIn + time();
+        $existingData['expires_in'] = $expiresIn;
 
         (new Settings())->updateConnection($senderEmail, $existingData);
-        return fluentMailGetProvider($senderEmail, true); // we are clearing the static cache here
+
+        fluentMailGetProvider($senderEmail, true); // we are clearing the static cache here
+
+        // Keep the token warm even on a site that is not sending, so an idle
+        // stretch cannot quietly age the refresh token out. See Gmail, which
+        // has had this since day one.
+        wp_schedule_single_event($existingData['expire_stamp'] - 360, 'fluentsmtp_renew_outlook_token');
+
+        return true;
     }
 
-    private function getAccessToken($config)
+    private function getAccessToken($config, $force = false)
     {
-        $accessToken = $config['access_token'];
+        $accessToken = Arr::get($config, 'access_token');
+        $expireStamp = (int)Arr::get($config, 'expire_stamp');
+
         // check if expired or will be expired in 300 seconds
-        if ( ($config['expire_stamp'] - 300) < time()) {
+        if ($force || ($expireStamp - 300) < time()) {
             $fluentAPi = (new API($config['client_id'], $config['client_secret']));
 
             $tokens = $fluentAPi->sendTokenRequest('refresh_token', [
-                'refresh_token' => $config['refresh_token']
+                'refresh_token' => Arr::get($config, 'refresh_token')
             ]);
 
-            if(is_wp_error($tokens)) {
-                return false;
+            /*
+             * This used to return false, and the caller then handed `false` to
+             * the Graph API as the bearer token. The send failed with a generic
+             * 401 while the real reason - an expired or revoked refresh token,
+             * fixable only by reconnecting the account - was discarded here and
+             * never reached the log or the admin.
+             */
+            if (is_wp_error($tokens)) {
+                throw new \Exception(
+                    sprintf(
+                    /* translators: %s: error message returned by Microsoft */
+                        __('Could not renew the Microsoft access token: %s. Please reconnect this Outlook connection in FluentSMTP settings.', 'fluent-smtp'),
+                        $tokens->get_error_message()
+                    )
+                );
             }
 
             $this->saveNewTokens($config, $tokens);
 
-            $accessToken =  $tokens['access_token'];
+            $accessToken = Arr::get($tokens, 'access_token');
+        }
+
+        if (empty($accessToken)) {
+            throw new \Exception(
+                __('No usable Microsoft access token is available for this connection. Please reconnect this Outlook connection in FluentSMTP settings.', 'fluent-smtp')
+            );
         }
 
         return $accessToken;
@@ -179,21 +252,29 @@ class Handler extends BaseHandler
 
     public function getConnectionInfo($connection)
     {
-        if (Arr::get($connection, 'key_store') == 'wp_config') {
-            $connection['client_id'] = defined('FLUENTMAIL_OUTLOOK_CLIENT_ID') ? FLUENTMAIL_OUTLOOK_CLIENT_ID : '';
-            $connection['client_secret'] = defined('FLUENTMAIL_OUTLOOK_CLIENT_SECRET') ? FLUENTMAIL_OUTLOOK_CLIENT_SECRET : '';
+        $connection = self::withResolvedKeys($connection);
+
+        $tokenError = '';
+
+        try {
+            $this->getAccessToken($connection);
+        } catch (\Exception $e) {
+            // Reporting why the token could not be renewed is the whole point
+            // of this panel, so a failure here is shown rather than thrown.
+            $tokenError = $e->getMessage();
         }
 
-        $this->getAccessToken($connection);
         $info = fluentMailgetConnection($connection['sender_email']);
         $connection = $info->getSetting();
 
         $extraRow = [
             'title'   => __('Token Validity', 'fluent-smtp'),
-            'content' => 'Valid (' . intval((($connection['expire_stamp'] - time()) / 60)) . 'm)'
+            'content' => 'Valid (' . intval(((Arr::get($connection, 'expire_stamp') - time()) / 60)) . 'm)'
         ];
 
-        if (($connection['expire_stamp']) < time()) {
+        if ($tokenError) {
+            $extraRow['content'] = $tokenError;
+        } elseif (Arr::get($connection, 'expire_stamp') < time()) {
             $extraRow['content'] = 'Invalid. Please re-authenticate';
         }
 

--- a/database/migrations/EmailLogs.php
+++ b/database/migrations/EmailLogs.php
@@ -36,10 +36,62 @@ class EmailLogs
                 `source` VARCHAR(255) NULL,
                 `created_at` TIMESTAMP NULL,
                 `updated_at` TIMESTAMP NULL,
-                INDEX `status` (`status`)
+                INDEX `created_at_status` (`created_at`, `status`)
             ) $charsetCollate;";
 
             dbDelta($sql);
+        } else {
+            self::maybeUpgradeIndexes($table);
         }
+    }
+
+    /**
+     * Replace the old single-column `status` index with one that leads on
+     * `created_at`.
+     *
+     * Every query against this table constrains a date range - the dashboard
+     * counters pair it with a status, while the report chart, the day/time
+     * heatmap and the pruning cron filter on the date alone. Leading with
+     * `created_at` therefore serves all of them from one index. Leading with
+     * `status` would only serve the first group, and barely: a log is
+     * overwhelmingly 'sent', so that column narrows almost nothing.
+     *
+     * This only runs from migrate(), i.e. on activation and on new-site
+     * creation - never on a normal page load. Reindexing a table that can hold
+     * millions of rows is not free, so it must stay off the request path.
+     *
+     * @param string $table
+     * @return void
+     */
+    private static function maybeUpgradeIndexes($table)
+    {
+        global $wpdb;
+
+        if (!self::hasIndex($table, 'created_at_status')) {
+            $wpdb->query("ALTER TABLE $table ADD INDEX `created_at_status` (`created_at`, `status`)");
+        }
+
+        /*
+         * Dropped last, and only once the replacement is confirmed present, so
+         * the table is never left with no index covering `status` at all.
+         */
+        if (self::hasIndex($table, 'status') && self::hasIndex($table, 'created_at_status')) {
+            $wpdb->query("ALTER TABLE $table DROP INDEX `status`");
+        }
+    }
+
+    /**
+     * @param string $table
+     * @param string $indexName
+     * @return bool
+     */
+    private static function hasIndex($table, $indexName)
+    {
+        global $wpdb;
+
+        // Table name is static/hard-coded, so wpdb->prepare() is sufficient
+        return (bool)$wpdb->get_var(
+            $wpdb->prepare("SHOW INDEX FROM $table WHERE Key_name = %s", $indexName)
+        );
     }
 }

--- a/includes/OAuth2Provider.php
+++ b/includes/OAuth2Provider.php
@@ -185,21 +185,43 @@ class OAuth2Provider
             );
         }
 
-        $responseBody = wp_remote_retrieve_body($response);
+        $responseBody = json_decode(wp_remote_retrieve_body($response), true);
 
-        if (false === is_array($response)) {
+        if (!is_array($responseBody)) {
             throw new \Exception(
                 'Invalid response received from Authorization Server. Expected JSON.'
             );
         }
 
-        if(empty(['access_token'])) {
+        /*
+         * The identity server answers a rejected grant with HTTP 400 and a JSON
+         * body describing why - most often invalid_grant, meaning the refresh
+         * token was revoked or expired through inactivity and the account has
+         * to be reconnected. That description is the only thing that tells a
+         * site owner what to actually do, so it is surfaced verbatim instead of
+         * being flattened into a generic failure.
+         */
+        if (!empty($responseBody['error'])) {
+            $description = '';
+
+            if (!empty($responseBody['error_description'])) {
+                $description = $responseBody['error_description'];
+            } elseif (is_string($responseBody['error'])) {
+                $description = $responseBody['error'];
+            }
+
             throw new \Exception(
-                'Invalid response received from Authorization Server.'
+                wp_kses_post('Authorization Server rejected the request: ' . $description)
             );
         }
 
-        return \json_decode($responseBody, true);
+        if (empty($responseBody['access_token'])) {
+            throw new \Exception(
+                'Invalid response received from Authorization Server. No access token was returned.'
+            );
+        }
+
+        return $responseBody;
     }
 
 

--- a/includes/Support/ValidationException.php
+++ b/includes/Support/ValidationException.php
@@ -9,7 +9,7 @@ class ValidationException extends Exception
 
     protected $errors = [];
 
-    public function __construct($message = "", $code = 0 , Exception $previous = NULL, $errors = [])
+    public function __construct($message = "", $code = 0, ?Exception $previous = null, $errors = [])
     {
         $this->errors = $errors;
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "description": "---",
     "main": ".eslintrc.js",
     "scripts": {
-        "start": "webpack --mode=development --node-env=development --progress --watch",
-        "prod": "webpack --mode=production --node-env=production --progress"
+        "start": "mix watch",
+        "prod": "mix --production"
     },
     "repository": {
         "type": "git",

--- a/resources/admin/Modules/Dashboard/Dashboard.vue
+++ b/resources/admin/Modules/Dashboard/Dashboard.vue
@@ -25,6 +25,16 @@
             </div>
         </div>
         <div v-else>
+            <el-alert
+                v-for="connection in unhealthy_settings"
+                :key="connection.sender_email"
+                type="error"
+                :closable="false"
+                show-icon
+                style="margin-bottom: 15px;"
+                :title="$t('Connection needs attention') + ': ' + connection.sender_email + ' (' + connection.provider + ')'"
+                :description="connection.message"
+            />
             <el-row :gutter="20">
                 <el-col :sm="24" :md="16">
                     <div class="fss_dashboard_widget">
@@ -129,6 +139,7 @@ export default {
             stats: {},
             new_connection: {},
             settings_stat: {},
+            unhealthy_settings: [],
             date_range: '',
             showing_chart: true,
             pickerOptions: {
@@ -187,6 +198,7 @@ export default {
             this.$get('/').then(res => {
                 this.stats = res.stats;
                 this.settings_stat = res.settings_stat;
+                this.unhealthy_settings = res.unhealthy_settings || [];
             }).fail(error => {
                 console.log(error);
             }).always(() => {


### PR DESCRIPTION
This pull request introduces a new connection health monitoring system, improves log deletion efficiency, and adds WP-CLI support for FluentSMTP. The main changes include a new `ConnectionHealth` service for proactively checking email connection status, batch deletion of old log entries to prevent timeouts, and a set of WP-CLI commands for managing and monitoring FluentSMTP from the command line. Additionally, notification mechanisms for unhealthy connections and improvements to provider handling logic are included.

**Connection health monitoring and notification:**
* Added `ConnectionHealth` service (`app/Services/ConnectionHealth.php`) to periodically check all configured email connections, store their health status, and provide methods to retrieve failing connections. It also triggers notifications when a connection newly fails.
* Updated `SchedulerHandler` to run connection health checks daily, renew Outlook tokens, and notify via configured channels (Slack, Telegram, Discord, Pushover) when a connection starts failing. [[1]](diffhunk://#diff-2a54be3b02eb7d58b390a8e2b7948024081e8fae74ed04e64a89f6f0806b5f62R22-R44) [[2]](diffhunk://#diff-2a54be3b02eb7d58b390a8e2b7948024081e8fae74ed04e64a89f6f0806b5f62R234-R333)

**WP-CLI integration:**
* Introduced a new `CliHandler` class (`app/Services/CliHandler.php`) and registered the `wp fluent-smtp` command, providing subcommands for testing email sending, checking connection health, viewing stats, and pruning logs. [[1]](diffhunk://#diff-459e8ffba13e1f4ef2a2f8f28b70867a1d4ab9b1eae8e4d1efa24a0f96579901R1-R215) [[2]](diffhunk://#diff-9d9435201b399cc92a2439802c46223e85d10b1b18c3a900708136f5cc2b7a6cR58-R73)

**Log management improvements:**
* Changed log deletion in `Logger::deleteLogsOlderThan()` to operate in batches, reducing the risk of database lock timeouts on large log tables.

**Dashboard and error handling enhancements:**
* Updated the dashboard controller to report unhealthy connections in its API response.
* Improved Gmail token renewal error reporting to provide actionable messages instead of generic failures.

**Provider handling fixes:**
* Fixed provider settings handling in `Factory::get()` to avoid fatal errors when falling back to the default connection.