### PR TITLE
Fix/strict sql reports

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -58,7 +58,7 @@ class DashboardController extends Controller
                         DAYNAME(created_at),
                         HOUR(created_at)
                     ORDER BY
-                        FIELD(DAYNAME(created_at), 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'),
+                        MIN(WEEKDAY(created_at)),
                         HOUR(created_at)",
                     $lastDay
                 )
@@ -77,7 +77,7 @@ class DashboardController extends Controller
                     DAYNAME(created_at),
                     HOUR(created_at)
                 ORDER BY
-                    FIELD(DAYNAME(created_at), 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'),
+                    MIN(WEEKDAY(created_at)),
                     HOUR(created_at)"
             );
         }

--- a/app/Http/Controllers/DiscordController.php
+++ b/app/Http/Controllers/DiscordController.php
@@ -49,6 +49,8 @@ class DiscordController extends Controller
 
     public function sendTestMessage(Request $request)
     {
+        $this->verify();
+
         // Let's update the notification status
         $settings = (new Settings())->notificationSettings();
 
@@ -77,6 +79,8 @@ class DiscordController extends Controller
 
     public function disconnect()
     {
+        $this->verify();
+
         NotificationHelper::updateChannelSettings('discord', [
             'status'       => 'no',
             'webhook_url'  => '',

--- a/app/Http/Controllers/PushoverController.php
+++ b/app/Http/Controllers/PushoverController.php
@@ -40,6 +40,8 @@ class PushoverController extends Controller
 
     public function sendTestMessage(Request $request)
     {
+        $this->verify();
+
         $settings = (new Settings())->notificationSettings();
 
         if (Arr::get($settings, 'pushover.status') != 'yes') {
@@ -68,6 +70,8 @@ class PushoverController extends Controller
 
     public function disconnect()
     {
+        $this->verify();
+
         NotificationHelper::updateChannelSettings('pushover', [
             'status'    => 'no',
             'api_token' => '',

--- a/app/Http/Controllers/SlackController.php
+++ b/app/Http/Controllers/SlackController.php
@@ -57,6 +57,8 @@ class SlackController extends Controller
 
     public function sendTestMessage(Request $request)
     {
+        $this->verify();
+
         // Let's update the notification status
         $settings = (new Settings())->notificationSettings();
 
@@ -84,6 +86,8 @@ class SlackController extends Controller
 
     public function disconnect()
     {
+        $this->verify();
+
         NotificationHelper::updateChannelSettings('slack', [
             'status'      => 'no',
             'webhook_url' => '',

--- a/app/Http/Controllers/TelegramController.php
+++ b/app/Http/Controllers/TelegramController.php
@@ -115,6 +115,8 @@ class TelegramController extends Controller
 
     public function sendTestMessage(Request $request)
     {
+        $this->verify();
+
         // Let's update the notification status
         $settings = (new Settings())->notificationSettings();
 
@@ -140,6 +142,8 @@ class TelegramController extends Controller
 
     public function disconnect()
     {
+        $this->verify();
+
         $settings = (new Settings())->notificationSettings();
 
         $token = Arr::get($settings, 'telegram.token');

--- a/app/Services/Reporting.php
+++ b/app/Services/Reporting.php
@@ -42,7 +42,7 @@ class Reporting
             // Use YYYY-MM format to prevent merging months across different years
             // Use first day of month as deterministic bucket date for alignment with DatePeriod
             // Note: %% escapes % for wpdb->prepare() - will become single % in final SQL
-            $selectClause = "COUNT(id) AS count, DATE_FORMAT(created_at, '%%Y-%%m-01') AS date, DATE_FORMAT(created_at, '%%Y-%%m') AS month";
+            $selectClause = "COUNT(id) AS count, MIN(DATE_FORMAT(created_at, '%%Y-%%m-01')) AS date, DATE_FORMAT(created_at, '%%Y-%%m') AS month";
         } else {
             // Default: group by date (daily stats)
             $selectClause = 'COUNT(id) AS count, DATE(created_at) AS date';

--- a/app/Services/Reporting.php
+++ b/app/Services/Reporting.php
@@ -37,7 +37,7 @@ class Reporting
             // Use YEARWEEK to prevent merging weeks across different years
             // Mode 1 ensures weeks start on Monday (ISO 8601 standard)
             // Use Monday of each week as deterministic bucket date for alignment with DatePeriod
-            $selectClause = 'COUNT(id) AS count, DATE(DATE_SUB(created_at, INTERVAL WEEKDAY(created_at) DAY)) AS date, YEARWEEK(created_at, 1) AS week';
+            $selectClause = 'COUNT(id) AS count, MIN(DATE(DATE_SUB(created_at, INTERVAL WEEKDAY(created_at) DAY))) AS date, YEARWEEK(created_at, 1) AS week';
         } elseif ($groupBy === 'month') {
             // Use YYYY-MM format to prevent merging months across different years
             // Use first day of month as deterministic bucket date for alignment with DatePeriod

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,7 @@ zip -r $ZIP_NAME . \
     -x "webpack.config.js" \
     -x "translation.node.js" \
     -x "webpack.mix.js" \
+    -x "vitest.config.mjs" \
     -x "package.json" \
     -x "package-lock.json" \
     -x "pnpm-lock.yaml" \

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "main": ".eslintrc.js",
     "scripts": {
         "start": "mix watch",
-        "prod": "mix --production"
+        "prod": "mix --production",
+        "test:js": "vitest run --config vitest.config.mjs"
     },
     "repository": {
         "type": "git",
@@ -26,6 +27,7 @@
         "resolve-url-loader": "^4.0.0",
         "sass": "^1.36.0",
         "sass-loader": "^12.1.0",
+        "vitest": "^4.1.10",
         "vue-loader": "^15.9.7",
         "vue-template-compiler": "^2.6.14"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 1.13.8
       laravel-mix:
         specifier: ^6.0.25
-        version: 6.0.49(@babel/core@7.23.7)(@babel/plugin-proposal-object-rest-spread@7.20.7)(@babel/plugin-syntax-dynamic-import@7.8.3)(@babel/plugin-transform-runtime@7.23.7)(@babel/preset-env@7.23.7)(postcss@8.4.32)(webpack-cli@4.10.0)(webpack@5.89.0)
+        version: 6.0.49(@babel/core@7.23.7)(@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.23.7))(@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.7))(@babel/plugin-transform-runtime@7.23.7(@babel/core@7.23.7))(@babel/preset-env@7.23.7(@babel/core@7.23.7))(postcss@8.4.32)(webpack-cli@4.10.0)(webpack@5.89.0)
       resolve-url-loader:
         specifier: ^4.0.0
         version: 4.0.0
@@ -54,9 +54,12 @@ importers:
       sass-loader:
         specifier: ^12.1.0
         version: 12.6.0(sass@1.69.6)(webpack@5.89.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(vite@8.2.0(sass@1.69.6)(terser@5.26.0))
       vue-loader:
         specifier: ^15.9.7
-        version: 15.11.1(css-loader@5.2.7)(lodash@4.17.21)(vue-template-compiler@2.7.16)(webpack@5.89.0)
+        version: 15.11.1(css-loader@5.2.7(webpack@5.89.0))(lodash@4.17.21)(vue-template-compiler@2.7.16)(webpack@5.89.0)
       vue-template-compiler:
         specifier: ^2.6.14
         version: 2.7.16
@@ -676,6 +679,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.20':
     resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
 
@@ -693,6 +699,105 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+
+  '@rolldown/binding-android-arm64@1.2.2':
+    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.2':
+    resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.2':
+    resolution: {integrity: sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.2':
+    resolution: {integrity: sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+    resolution: {integrity: sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+    resolution: {integrity: sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.2':
+    resolution: {integrity: sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+    resolution: {integrity: sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+    resolution: {integrity: sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.2':
+    resolution: {integrity: sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.2':
+    resolution: {integrity: sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.2':
+    resolution: {integrity: sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+    resolution: {integrity: sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.2':
+    resolution: {integrity: sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -716,6 +821,9 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chart.js@2.9.41':
     resolution: {integrity: sha512-3dvkDvueckY83UyUXtJMalYoH6faOLkWQoaTlJgB4Djde3oORmNP0Jw85HtzTuXyliUHcdp704s0mZFQKio/KQ==}
 
@@ -727,6 +835,9 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -815,6 +926,35 @@ packages:
   '@types/ws@8.5.10':
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@vue/compiler-sfc@2.7.16':
     resolution: {integrity: sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==}
 
@@ -902,6 +1042,7 @@ packages:
 
   acorn-import-assertions@1.9.0:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    deprecated: package has been renamed to acorn-import-attributes
     peerDependencies:
       acorn: ^8
 
@@ -974,6 +1115,10 @@ packages:
 
   assert@1.5.1:
     resolution: {integrity: sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async-validator@1.8.5:
     resolution: {integrity: sha512-tXBM+1m056MAX0E8TL2iCjg8WvSyXu0Zc8LNtYqrVeyoL3+esHRZ4SieE9fKQyyU09uONjnMEjrNBMqT0mbvmA==}
@@ -1120,6 +1265,10 @@ packages:
 
   caniuse-lite@1.0.30001572:
     resolution: {integrity: sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -1562,6 +1711,10 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
@@ -1653,6 +1806,9 @@ packages:
   es-module-lexer@1.4.1:
     resolution: {integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -1680,6 +1836,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1701,6 +1860,10 @@ packages:
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.18.2:
     resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
@@ -1726,6 +1889,15 @@ packages:
   faye-websocket@0.11.4:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
     engines: {node: '>=0.8.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-loader@6.2.0:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
@@ -2120,6 +2292,80 @@ packages:
   launch-editor@2.6.1:
     resolution: {integrity: sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==}
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
@@ -2167,6 +2413,9 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -2265,6 +2514,11 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2328,6 +2582,10 @@ packages:
 
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -2420,6 +2678,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pbkdf2@3.1.2:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
     engines: {node: '>=0.12'}
@@ -2430,9 +2691,16 @@ packages:
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -2657,6 +2925,10 @@ packages:
     resolution: {integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -2826,6 +3098,11 @@ packages:
   ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
 
+  rolldown@1.2.2:
+    resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2943,6 +3220,9 @@ packages:
   side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2958,6 +3238,10 @@ packages:
 
   source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
@@ -2978,6 +3262,9 @@ packages:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
     deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -2988,6 +3275,9 @@ packages:
 
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stream-browserify@2.0.2:
     resolution: {integrity: sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==}
@@ -3087,6 +3377,21 @@ packages:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
     engines: {node: '>=0.6.0'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
   to-arraybuffer@1.0.1:
     resolution: {integrity: sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==}
 
@@ -3171,6 +3476,90 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vite@8.2.0:
+    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
 
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
@@ -3312,6 +3701,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wildcard@2.0.1:
@@ -4118,6 +4512,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.20':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
@@ -4136,6 +4532,54 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
+
+  '@oxc-project/types@0.142.0': {}
+
+  '@rolldown/binding-android-arm64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@trysound/sax@0.2.0': {}
 
@@ -4169,6 +4613,11 @@ snapshots:
     dependencies:
       '@types/node': 20.10.6
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/chart.js@2.9.41':
     dependencies:
       moment: 2.30.1
@@ -4186,6 +4635,8 @@ snapshots:
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 20.10.6
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -4293,6 +4744,47 @@ snapshots:
   '@types/ws@8.5.10':
     dependencies:
       '@types/node': 20.10.6
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.0(sass@1.69.6)(terser@5.26.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.0(sass@1.69.6)(terser@5.26.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@vue/compiler-sfc@2.7.16':
     dependencies:
@@ -4484,7 +4976,7 @@ snapshots:
       regex-parser: 2.2.11
 
   ajv-formats@2.1.1(ajv@8.12.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.12.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -4544,6 +5036,8 @@ snapshots:
     dependencies:
       object.assign: 4.1.5
       util: 0.10.4
+
+  assertion-error@2.0.1: {}
 
   async-validator@1.8.5:
     dependencies:
@@ -4744,6 +5238,8 @@ snapshots:
 
   caniuse-lite@1.0.30001572: {}
 
+  chai@6.2.2: {}
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -4861,6 +5357,7 @@ snapshots:
   consolidate@0.15.1(lodash@4.17.21):
     dependencies:
       bluebird: 3.7.2
+    optionalDependencies:
       lodash: 4.17.21
 
   constants-browserify@1.0.0: {}
@@ -5067,6 +5564,8 @@ snapshots:
 
   destroy@1.2.0: {}
 
+  detect-libc@2.1.2: {}
+
   detect-node@2.1.0: {}
 
   diffie-hellman@5.0.3:
@@ -5163,6 +5662,8 @@ snapshots:
 
   es-module-lexer@1.4.1: {}
 
+  es-module-lexer@2.3.1: {}
+
   escalade@3.1.1: {}
 
   escape-html@1.0.3: {}
@@ -5181,6 +5682,10 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.5
 
   esutils@2.0.3: {}
 
@@ -5206,6 +5711,8 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  expect-type@1.4.0: {}
 
   express@4.18.2:
     dependencies:
@@ -5264,6 +5771,10 @@ snapshots:
   faye-websocket@0.11.4:
     dependencies:
       websocket-driver: 0.7.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   file-loader@6.2.0(webpack@5.89.0):
     dependencies:
@@ -5468,12 +5979,13 @@ snapshots:
 
   http-proxy-middleware@2.0.6(@types/express@4.17.21):
     dependencies:
-      '@types/express': 4.17.21
       '@types/http-proxy': 1.17.14
       http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.5
+    optionalDependencies:
+      '@types/express': 4.17.21
     transitivePeerDependencies:
       - debug
 
@@ -5621,7 +6133,7 @@ snapshots:
 
   klona@2.0.6: {}
 
-  laravel-mix@6.0.49(@babel/core@7.23.7)(@babel/plugin-proposal-object-rest-spread@7.20.7)(@babel/plugin-syntax-dynamic-import@7.8.3)(@babel/plugin-transform-runtime@7.23.7)(@babel/preset-env@7.23.7)(postcss@8.4.32)(webpack-cli@4.10.0)(webpack@5.89.0):
+  laravel-mix@6.0.49(@babel/core@7.23.7)(@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.23.7))(@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.7))(@babel/plugin-transform-runtime@7.23.7(@babel/core@7.23.7))(@babel/preset-env@7.23.7(@babel/core@7.23.7))(postcss@8.4.32)(webpack-cli@4.10.0)(webpack@5.89.0):
     dependencies:
       '@babel/core': 7.23.7
       '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.23.7)
@@ -5690,6 +6202,55 @@ snapshots:
       picocolors: 1.0.0
       shell-quote: 1.8.1
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lilconfig@2.1.0: {}
 
   lines-and-columns@1.2.4: {}
@@ -5736,6 +6297,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-dir@3.1.0:
     dependencies:
@@ -5823,6 +6388,8 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
+  nanoid@3.3.17: {}
+
   nanoid@3.3.7: {}
 
   negotiator@0.6.3: {}
@@ -5901,6 +6468,8 @@ snapshots:
       object-keys: 1.1.1
 
   obuf@1.1.2: {}
+
+  obug@2.1.4: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -5988,6 +6557,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   pbkdf2@3.1.2:
     dependencies:
       create-hash: 1.2.0
@@ -6000,7 +6571,11 @@ snapshots:
 
   picocolors@1.0.0: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
+
+  picomatch@4.0.5: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -6045,8 +6620,9 @@ snapshots:
   postcss-load-config@3.1.4(postcss@8.4.32):
     dependencies:
       lilconfig: 2.1.0
-      postcss: 8.4.32
       yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.4.32
 
   postcss-loader@6.2.1(postcss@8.4.32)(webpack@5.89.0):
     dependencies:
@@ -6207,6 +6783,12 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.17
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prettier@2.8.8:
     optional: true
 
@@ -6366,6 +6948,26 @@ snapshots:
       hash-base: 3.1.0
       inherits: 2.0.4
 
+  rolldown@1.2.2:
+    dependencies:
+      '@oxc-project/types': 0.142.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.2
+      '@rolldown/binding-darwin-arm64': 1.2.2
+      '@rolldown/binding-darwin-x64': 1.2.2
+      '@rolldown/binding-freebsd-x64': 1.2.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.2
+      '@rolldown/binding-linux-arm64-gnu': 1.2.2
+      '@rolldown/binding-linux-arm64-musl': 1.2.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.2
+      '@rolldown/binding-linux-s390x-gnu': 1.2.2
+      '@rolldown/binding-linux-x64-gnu': 1.2.2
+      '@rolldown/binding-linux-x64-musl': 1.2.2
+      '@rolldown/binding-openharmony-arm64': 1.2.2
+      '@rolldown/binding-win32-arm64-msvc': 1.2.2
+      '@rolldown/binding-win32-x64-msvc': 1.2.2
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6380,8 +6982,9 @@ snapshots:
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
-      sass: 1.69.6
       webpack: 5.89.0(webpack-cli@4.10.0)
+    optionalDependencies:
+      sass: 1.69.6
 
   sass@1.69.6:
     dependencies:
@@ -6502,6 +7105,8 @@ snapshots:
       get-intrinsic: 1.2.2
       object-inspect: 1.13.1
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   slash@3.0.0: {}
@@ -6515,6 +7120,8 @@ snapshots:
   source-list-map@2.0.1: {}
 
   source-map-js@1.0.2: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -6546,11 +7153,15 @@ snapshots:
 
   stable@0.1.8: {}
 
+  stackback@0.0.2: {}
+
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
 
   std-env@3.7.0: {}
+
+  std-env@4.2.0: {}
 
   stream-browserify@2.0.2:
     dependencies:
@@ -6654,6 +7265,17 @@ snapshots:
     dependencies:
       setimmediate: 1.0.5
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
+
   to-arraybuffer@1.0.1: {}
 
   to-fast-properties@2.0.0: {}
@@ -6721,6 +7343,43 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite@8.2.0(sass@1.69.6)(terser@5.26.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rolldown: 1.2.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+      sass: 1.69.6
+      terser: 5.26.0
+
+  vitest@4.1.10(vite@8.2.0(sass@1.69.6)(terser@5.26.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(sass@1.69.6)(terser@5.26.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(sass@1.69.6)(terser@5.26.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
   vm-browserify@1.1.2: {}
 
   vue-chartjs@3.5.1(chart.js@3.9.1):
@@ -6730,7 +7389,7 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(css-loader@5.2.7)(lodash@4.17.21)(vue-template-compiler@2.7.16)(webpack@5.89.0):
+  vue-loader@15.11.1(css-loader@5.2.7(webpack@5.89.0))(lodash@4.17.21)(vue-template-compiler@2.7.16)(webpack@5.89.0):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)
       css-loader: 5.2.7(webpack@5.89.0)
@@ -6738,8 +7397,9 @@ snapshots:
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.3
-      vue-template-compiler: 2.7.16
       webpack: 5.89.0(webpack-cli@4.10.0)
+    optionalDependencies:
+      vue-template-compiler: 2.7.16
     transitivePeerDependencies:
       - arc-templates
       - atpl
@@ -6880,10 +7540,11 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.89.0(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack@5.89.0)
       webpack-dev-middleware: 5.3.3(webpack@5.89.0)
       ws: 8.16.0
+    optionalDependencies:
+      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack-cli: 4.10.0(webpack@5.89.0)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -6933,8 +7594,9 @@ snapshots:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(webpack@5.89.0)
       watchpack: 2.4.0
-      webpack-cli: 4.10.0(webpack@5.89.0)
       webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack-cli: 4.10.0(webpack@5.89.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -6959,6 +7621,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wildcard@2.0.1: {}
 

--- a/tests/AGENT.md
+++ b/tests/AGENT.md
@@ -15,6 +15,7 @@ bash tests/bin/run-all.sh static
 bash tests/bin/run-all.sh smoke
 bash tests/bin/run-all.sh permissions
 bash tests/bin/run-all.sh integration
+FSMTP_STRICT_KNOWN_FAILURES=1 bash tests/bin/run-all.sh permissions
 
 wp eval-file tests/bin/run-smoke.php
 wp eval-file tests/bin/run-smoke.php -- filter=logs
@@ -87,6 +88,8 @@ admin-AJAX manifest and should be tested separately if its behavior changes.
 - Assert behavior and returned values, not exact SQL or log text.
 - Clean up in `finally`. Cleanup must be exact and idempotent.
 - Promote FluentSMTP notices, warnings, and deprecations to failures.
+- Never print raw settings or provider request data; failure output must redact
+  credentials and URL query strings.
 - Clear only FluentSMTP-owned caches before each suite.
 
 The shared harness exposes:

--- a/tests/AGENT.md
+++ b/tests/AGENT.md
@@ -1,0 +1,131 @@
+# AGENT.md — rules for writing FluentSMTP tests
+
+Read this completely before writing a test. This suite runs locally through
+WP-CLI against the real development WordPress install. Do not introduce
+PHPUnit, Docker, `wp-env`, a CI service, real loopback HTTP, real cron, or
+`sleep()`.
+
+## Ground truth
+
+Run commands from the FluentSMTP plugin root:
+
+```bash
+bash tests/bin/run-all.sh
+bash tests/bin/run-all.sh static
+bash tests/bin/run-all.sh smoke
+bash tests/bin/run-all.sh permissions
+bash tests/bin/run-all.sh integration
+
+wp eval-file tests/bin/run-smoke.php
+wp eval-file tests/bin/run-smoke.php -- filter=logs
+```
+
+Paths are discovered from the runner location and WordPress itself. Never
+hardcode a WordPress root, site URL, or WordPress table prefix. The plugin table
+is `{$wpdb->prefix}fsmpt_email_logs`.
+
+Every runner must exit non-zero on failure. Every WP-CLI runner must finish via
+`FsmtpTest::finish()` so protected log counts are compared before exit.
+
+## Proof-of-catch
+
+Never keep a test you have not watched fail.
+
+For every test:
+
+1. Break the covered behavior in a production file or its test fixture.
+2. Run the narrow owning tier and observe red.
+3. Confirm the message describes the intended defect, not an incidental error.
+4. Restore the production file.
+5. Run the tier again and observe green.
+6. Record the red output in the phase commit message.
+
+If the test cannot be made to fail, delete it.
+
+## Absolute prohibitions
+
+- Never mock `$wpdb`, the query builder, or models. Use the real local database.
+- Mock only outbound third parties: SMTP/provider APIs and OAuth token endpoints.
+- Never send real email. `FLUENTMAIL_SIMULATE_EMAILS` must be truthy and every
+  case must assert that `fluentMailGetProvider()` resolved the Simulator handler.
+- Never make real HTTP or loopback calls. Install a fail-closed interceptor.
+- Never run cron and never sleep.
+- Never assert on pre-existing site data. Read-only smoke may use an existing log
+  ID and skip if none exists; behavioral assertions create isolated fixtures.
+- Never alter or delete a real `fsmpt_email_logs` row. Fixture IDs are recorded
+  and deleted in `finally`; the runner compares the protected row count before
+  and after every run.
+- Never fix production code in a test phase. Park a confirmed bug as
+  `KNOWN-FAILURE` and record it in `tests/FIX-PLAN.md` with file:line, symptom,
+  mechanism, and owning test.
+- Never weaken a test to make it pass.
+
+## AJAX rules
+
+All 42 admin routes are declared in `app/Http/routes.php`. The SPA calls them
+through WordPress admin-AJAX, not REST.
+
+- Keep every route in `tests/smoke/routes.manifest.php`.
+- Preserve every GET query variation the Vue app sends. Variations matter more
+  than the bare route count.
+- Derive action names only by calling
+  `Application::getAjaxAction($route, $method, $isAdmin)`. Never reconstruct an
+  action string in a test.
+- GET smoke is read-only (11 routes). Mutating happy paths for the 31 POST
+  routes belong in integration fixtures.
+- Permission smoke must prove every POST is unavailable anonymously and rejects
+  a logged-in low-privilege user. Its option-write and HTTP fuses must stay on.
+
+The sole REST route, `fluent-smtp/outlook_callback`, is outside the 42-route
+admin-AJAX manifest and should be tested separately if its behavior changes.
+
+## Test shape
+
+- Name one behavior per case.
+- Arrange, act, assert in that order.
+- Use `FsmtpTest::uniq()` for collision-free fixture values.
+- Assert behavior and returned values, not exact SQL or log text.
+- Clean up in `finally`. Cleanup must be exact and idempotent.
+- Promote FluentSMTP notices, warnings, and deprecations to failures.
+- Clear only FluentSMTP-owned caches before each suite.
+
+The shared harness exposes:
+
+```php
+FsmtpTest::boot();
+FsmtpTest::case('behavior name', function () {});
+FsmtpTest::ajax('GET', '/logs', ['page' => 1]);
+FsmtpTest::assertAjaxHealthy($result, 'label');
+FsmtpTest::assert($condition, 'detail');
+FsmtpTest::assertSame($expected, $actual, 'label');
+FsmtpTest::assertMailSimulationActive();
+FsmtpTest::interceptHttp($responder);
+FsmtpTest::uniq('fixture');
+FsmtpTest::finish('SUITE');
+```
+
+Add a reusable primitive to `tests/lib/harness.php` with a comment explaining
+the safety or fidelity reason; do not hide one-off mock behavior inside tests.
+
+## Findings and reporting
+
+Production findings go in `tests/FIX-PLAN.md`. Proof-of-catch output, skips,
+runtime, and case counts go in the phase commit message:
+
+```text
+Cases added: <count>   Suite runtime: <seconds>
+
+Proof-of-catch:
+  <case> — broke <behavior>, observed: <red failure>
+
+Deliberately skipped:
+  <case> — <reason>
+
+Needs a human decision:
+  <surprise or environment gap>
+```
+
+Never commit a red tier. If a case is flaky, skip it with a documented reason;
+do not report it green. This install currently uses the default `wp_` prefix, so
+prefix portability is an explicit environment gap until the suite is also run
+on a non-default-prefix install.

--- a/tests/FIX-PLAN.md
+++ b/tests/FIX-PLAN.md
@@ -1,10 +1,9 @@
-# FIX-PLAN.md — open bug and test-gap backlog
+# FIX-PLAN.md — bug and test-gap record
 
-> Findings from test-writing runs. Production fixes are deliberately separate
-> from this branch; parked `KNOWN-FAILURE` cases stay visible while tiers remain
-> green.
+> Findings from test-writing runs. There are currently no open
+> `KNOWN-FAILURE` items; resolved entries remain below as regression history.
 
-## KNOWN-FAILURE — weekly reporting fails with `ONLY_FULL_GROUP_BY`
+## RESOLVED — weekly reporting failed with `ONLY_FULL_GROUP_BY`
 
 - Production: `app/Services/Reporting.php:40,58`
 - Symptom: `Reporting::getSendingStats()` returns no weekly rows and `$wpdb`
@@ -14,8 +13,11 @@
   infer that the projected expression is functionally dependent on that alias.
 - Owning tests: `weekly report aggregate is tracked under strict SQL modes` and
   the `GET sending_stats` smoke variations when they select weekly frequency.
+- Resolution: `e7a2b2f9` aggregates the deterministic Monday expression without
+  changing the bucket date. Both normal and strict-known-failure suites run the
+  real Monday-bucket assertion successfully on both installs.
 
-## KNOWN-FAILURE — monthly reporting fails with `ONLY_FULL_GROUP_BY`
+## RESOLVED — monthly reporting failed with `ONLY_FULL_GROUP_BY`
 
 - Production: `app/Services/Reporting.php:45,58`
 - Symptom: `Reporting::getSendingStats()` returns no monthly rows and `$wpdb`
@@ -24,8 +26,12 @@
   value derived from `created_at`, but groups only by the year-month alias.
 - Owning tests: `monthly report aggregate is tracked under strict SQL modes` and
   the `GET sending_stats` smoke variations when they select monthly frequency.
+- Resolution: `6faeb96f` aggregates the deterministic first-of-month
+  expression without changing the bucket date. Both normal and
+  strict-known-failure suites run the real month-bucket assertion successfully
+  on both installs.
 
-## KNOWN-FAILURE — heatmap ordering fails with `ONLY_FULL_GROUP_BY`
+## RESOLVED — heatmap ordering failed with `ONLY_FULL_GROUP_BY`
 
 - Production: `app/Http/Controllers/DashboardController.php:60-62,79-81`
 - Symptom: both all-time and bounded day/time heatmap queries return no rows and
@@ -36,3 +42,6 @@
 - Owning tests: strict-mode `GET /day-time-stats` smoke variations, the
   site-local heatmap case, the clamped-lookback case, and `day-time heatmap
   aggregate is tracked under strict SQL modes`.
+- Resolution: `9bc02fb4` orders through the aggregate weekday value in both
+  query branches. Both normal and strict-known-failure suites run the real
+  heatmap assertions successfully on both installs.

--- a/tests/FIX-PLAN.md
+++ b/tests/FIX-PLAN.md
@@ -4,4 +4,35 @@
 > from this branch; parked `KNOWN-FAILURE` cases stay visible while tiers remain
 > green.
 
-No open findings or environment gaps.
+## KNOWN-FAILURE — weekly reporting fails with `ONLY_FULL_GROUP_BY`
+
+- Production: `app/Services/Reporting.php:40,58`
+- Symptom: `Reporting::getSendingStats()` returns no weekly rows and `$wpdb`
+  reports that SELECT expression 2 is not in the GROUP BY clause.
+- Mechanism: the SELECT projects a Monday date derived from `created_at`, but
+  groups only by the separate `YEARWEEK(created_at, 1)` alias. MySQL 8 does not
+  infer that the projected expression is functionally dependent on that alias.
+- Owning tests: `weekly report aggregate is tracked under strict SQL modes` and
+  the `GET sending_stats` smoke variations when they select weekly frequency.
+
+## KNOWN-FAILURE — monthly reporting fails with `ONLY_FULL_GROUP_BY`
+
+- Production: `app/Services/Reporting.php:45,58`
+- Symptom: `Reporting::getSendingStats()` returns no monthly rows and `$wpdb`
+  reports that SELECT expression 2 is not in the GROUP BY clause.
+- Mechanism: the SELECT projects both a first-of-month date and a year-month
+  value derived from `created_at`, but groups only by the year-month alias.
+- Owning tests: `monthly report aggregate is tracked under strict SQL modes` and
+  the `GET sending_stats` smoke variations when they select monthly frequency.
+
+## KNOWN-FAILURE — heatmap ordering fails with `ONLY_FULL_GROUP_BY`
+
+- Production: `app/Http/Controllers/DashboardController.php:60-62,79-81`
+- Symptom: both all-time and bounded day/time heatmap queries return no rows and
+  `$wpdb` reports that ORDER BY expression 1 is not in the GROUP BY clause.
+- Mechanism: the query groups by `DAYNAME(created_at)` and `HOUR(created_at)` but
+  orders through `FIELD(DAYNAME(created_at), ...)`; MySQL 8 rejects the FIELD
+  expression under `ONLY_FULL_GROUP_BY`.
+- Owning tests: strict-mode `GET /day-time-stats` smoke variations, the
+  site-local heatmap case, the clamped-lookback case, and `day-time heatmap
+  aggregate is tracked under strict SQL modes`.

--- a/tests/FIX-PLAN.md
+++ b/tests/FIX-PLAN.md
@@ -6,6 +6,7 @@
 
 | # | Item | Kind | Risk |
 |---|---|---|---|
+| 1 | `app/Http/Controllers/TelegramController.php:116,141`, `SlackController.php:58,85`, `DiscordController.php:50,78`, and `PushoverController.php:41,69` — each channel's `sendTestMessage()` and `disconnect()` omits `$this->verify()`. A logged-in subscriber with a valid FluentSMTP nonce reaches the handler; disconnect changes notification configuration and send-test can call a third party. Parked by the eight dynamic `KNOWN-FAILURE` permission cases. | Authorization | Critical |
 
 ## Environment gaps
 

--- a/tests/FIX-PLAN.md
+++ b/tests/FIX-PLAN.md
@@ -1,0 +1,15 @@
+# FIX-PLAN.md — open bug and test-gap backlog
+
+> Findings from test-writing runs. Production fixes are deliberately separate
+> from this branch; parked `KNOWN-FAILURE` cases stay visible while tiers remain
+> green.
+
+| # | Item | Kind | Risk |
+|---|---|---|---|
+
+## Environment gaps
+
+- The current development install uses the default `wp_` database prefix. The
+  suite resolves `$wpdb->prefix` correctly and the static gate covers raw SQL,
+  but a second run on a non-default-prefix install is still required to prove
+  runtime prefix portability.

--- a/tests/FIX-PLAN.md
+++ b/tests/FIX-PLAN.md
@@ -4,12 +4,4 @@
 > from this branch; parked `KNOWN-FAILURE` cases stay visible while tiers remain
 > green.
 
-| # | Item | Kind | Risk |
-|---|---|---|---|
-
-## Environment gaps
-
-- The current development install uses the default `wp_` database prefix. The
-  suite resolves `$wpdb->prefix` correctly and the static gate covers raw SQL,
-  but a second run on a non-default-prefix install is still required to prove
-  runtime prefix portability.
+No open findings or environment gaps.

--- a/tests/FIX-PLAN.md
+++ b/tests/FIX-PLAN.md
@@ -6,7 +6,6 @@
 
 | # | Item | Kind | Risk |
 |---|---|---|---|
-| 1 | `app/Http/Controllers/TelegramController.php:116,141`, `SlackController.php:58,85`, `DiscordController.php:50,78`, and `PushoverController.php:41,69` — each channel's `sendTestMessage()` and `disconnect()` omits `$this->verify()`. A logged-in subscriber with a valid FluentSMTP nonce reaches the handler; disconnect changes notification configuration and send-test can call a third party. Parked by the eight dynamic `KNOWN-FAILURE` permission cases. | Authorization | Critical |
 
 ## Environment gaps
 

--- a/tests/MUTATION-AUDIT.md
+++ b/tests/MUTATION-AUDIT.md
@@ -1,0 +1,88 @@
+# Phase 19 mutation audit
+
+Date: 2026-08-04
+
+Baseline: `tests/suite-round-3` after phase 20 (`a25b8530`)
+
+Command for every mutant: `bash tests/bin/run-all.sh`
+Full-suite shape: smoke 33, permissions 62, integration 48, zero skips
+
+Each mutation was applied to one production behavior at a time, exercised
+against the complete suite, and then reversed before the next mutation. The CLI
+pruning path was protected by a subprocess-only SQL fuse before removing the
+retention predicate; isolated fixture tables still received the actual mutant
+query. No production log row was changed.
+
+## Result
+
+- Mutants: 7
+- Killed: 4
+- Survived: 3
+- Kill rate: 57.1%
+
+The percentage is context, not a target. The survivor list below is the phase
+deliverable; no equivalent mutants were added to inflate the result.
+
+## Survivor list
+
+### S1 — report date-range predicate deletion
+
+- Production: `app/Services/Reporting.php:57`
+- Mutation: replaced `created_at BETWEEN <from> AND <to>` with a constant true
+  predicate while retaining both prepared parameters.
+- Full-suite result: survived; 33/33 smoke, 62/62 permissions, 48/48
+  integration, zero skips, protected log count unchanged.
+- Gap: report tests assert values for requested in-range buckets, but no fixture
+  outside the requested range is asserted absent from the returned chart.
+- Highest-value follow-up: add an isolated report fixture immediately before
+  and after the requested range and assert that neither contributes a bucket or
+  count.
+
+### S2 — Outlook expiry comparison reversal
+
+- Production: `app/Services/Mailer/Providers/Outlook/Handler.php:215`
+- Mutation: reversed the refresh threshold comparison from `< time()` to
+  `> time()`.
+- Full-suite result: survived; 33/33 smoke, 62/62 permissions, 48/48
+  integration, zero skips, protected log count unchanged.
+- Gap: current Outlook renewal coverage reaches the token request through paths
+  that force a refresh; it does not distinguish a still-valid cached token from
+  an expired token when `force` is false.
+- Highest-value follow-up: invoke `getAccessToken()` through reflection with
+  future and expired stamps, assert zero versus one intercepted token request,
+  and keep settings and scheduling fused.
+
+### S3 — replacement-index confirmation deletion
+
+- Production: `database/migrations/EmailLogs.php:78`
+- Mutation: removed the `created_at_status` existence check before dropping the
+  legacy `status` index.
+- Full-suite result: survived; 33/33 smoke, 62/62 permissions, 48/48
+  integration, zero skips, protected log count unchanged.
+- Gap: migration tests cover successful convergence and idempotence, but do not
+  force the replacement `ADD INDEX` to fail and prove the legacy status index
+  remains in place.
+- Highest-value follow-up: use a real incompatible pre-existing index state or
+  a fail-closed DDL query fixture, then assert that the legacy index is not
+  dropped after replacement creation fails.
+
+## Killed mutants
+
+| ID | Production mutation | Full-suite killer evidence |
+|---|---|---|
+| K1 | Removed the `created_at` predicate and its argument from `Logger::deleteLogsOlderThan()` (`app/Models/Logger.php:480`) | Integration failed on deleted count 5→8, retained rows 3→0, batch queries 3→5, the no-match row being deleted, and the site-local fixture deleting 2 instead of 1. |
+| K2 | Removed the `status` discriminator from both `Logger::getTotalCountStat()` branches (`app/Models/Logger.php:509,520`) | Dashboard Today counters changed from `[1,1]` to `[2,2]`; the open-ended failed count changed from 1 to 2. |
+| K3 | Reversed Gmail's expiry comparison (`app/Services/Mailer/Providers/Gmail/Handler.php:274`) | The rejected-grant case received a client instead of `WP_Error` and failed before the expected provider detail could be read. |
+| K4 | Removed the `created_at_status` existence guard before `ADD INDEX` (`database/migrations/EmailLogs.php:70`) | The idempotence case observed 2 `ALTER TABLE` statements instead of 0. |
+
+## Safety-fuse proof-of-catch
+
+The new CLI pruning case runs `prune-logs --days=1 --yes`, asserts the child
+process reports that the production-log `DELETE` was fused, expects zero
+deletions, and compares protected row counts. Changing only the child fixture's
+fuse marker made the owning integration case fail with:
+
+> child process did not prove the production-log write fuse
+
+The marker was restored and the filtered CLI tier returned 4/4 green before
+the mutation audit began.

--- a/tests/MUTATION-AUDIT.md
+++ b/tests/MUTATION-AUDIT.md
@@ -1,88 +1,106 @@
-# Phase 19 mutation audit
+# Phase 19 mutation audit — HEAD rerun
 
 Date: 2026-08-04
 
-Baseline: `tests/suite-round-3` after phase 20 (`a25b8530`)
+Baseline: `fix/strict-sql-reports` after the three survivor follow-ups
+(`17e36e90`)
 
 Command for every mutant: `bash tests/bin/run-all.sh`
-Full-suite shape: smoke 33, permissions 62, integration 48, zero skips
 
-Each mutation was applied to one production behavior at a time, exercised
-against the complete suite, and then reversed before the next mutation. The CLI
-pruning path was protected by a subprocess-only SQL fuse before removing the
-retention predicate; isolated fixture tables still received the actual mutant
-query. No production log row was changed.
+Full-suite shape: smoke 33, permissions 62, integration 58, zero skips.
+Every mutation was applied alone, exercised against the complete suite, and
+restored before the next mutation. The worktree was clean after every batch.
+The CLI pruning path remained protected by its subprocess-only production-log
+SQL fuse; pruning mutants executed only against isolated fixture tables.
 
 ## Result
 
-- Mutants: 7
-- Killed: 4
-- Survived: 3
-- Kill rate: 57.1%
+- Mutants: 20
+- Clause-deletion mutants: 18
+- Comparison-reversal mutants: 2
+- Killed: 16
+- Survived: 4
+- Kill rate: 80.0%
 
-The percentage is context, not a target. The survivor list below is the phase
-deliverable; no equivalent mutants were added to inflate the result.
+The percentage is context, not a target. Every survivor below completed the
+full 33/62/58 suite with zero failures and zero skips; the survivor list is the
+deliverable.
 
 ## Survivor list
 
-### S1 — report date-range predicate deletion
+### S1 — bounded heatmap `GROUP BY` deletion
 
-- Production: `app/Services/Reporting.php:57`
-- Mutation: replaced `created_at BETWEEN <from> AND <to>` with a constant true
-  predicate while retaining both prepared parameters.
-- Full-suite result: survived; 33/33 smoke, 62/62 permissions, 48/48
+- Production: `app/Http/Controllers/DashboardController.php:57-59`
+- Mutation: removed the bounded query's `GROUP BY DAYNAME(created_at),
+  HOUR(created_at)` clause.
+- Full-suite result: survived; 33/33 smoke, 62/62 permissions, 58/58
   integration, zero skips, protected log count unchanged.
-- Gap: report tests assert values for requested in-range buckets, but no fixture
-  outside the requested range is asserted absent from the returned chart.
-- Highest-value follow-up: add an isolated report fixture immediately before
-  and after the requested range and assert that neither contributes a bucket or
-  count.
+- Gap: bounded heatmap coverage exercises route health and lookback clamping,
+  but does not run two or more in-range weekday/hour groups from an isolated
+  table. The strict aggregate fixture uses only the all-time branch.
+- Highest-value follow-up: add an isolated strict-SQL bounded heatmap fixture
+  with rows in distinct weekday/hour groups and assert each returned cell.
 
-### S2 — Outlook expiry comparison reversal
+### S2 — bounded heatmap `ORDER BY` deletion
 
-- Production: `app/Services/Mailer/Providers/Outlook/Handler.php:215`
-- Mutation: reversed the refresh threshold comparison from `< time()` to
-  `> time()`.
-- Full-suite result: survived; 33/33 smoke, 62/62 permissions, 48/48
+- Production: `app/Http/Controllers/DashboardController.php:60-62`
+- Mutation: removed the bounded query's weekday/hour ordering.
+- Full-suite result: survived; 33/33 smoke, 62/62 permissions, 58/58
   integration, zero skips, protected log count unchanged.
-- Gap: current Outlook renewal coverage reaches the token request through paths
-  that force a refresh; it does not distinguish a still-valid cached token from
-  an expired token when `force` is false.
-- Highest-value follow-up: invoke `getAccessToken()` through reflection with
-  future and expired stamps, assert zero versus one intercepted token request,
-  and keep settings and scheduling fused.
+- Gap: the controller copies rows into a prebuilt weekday/hour matrix, so row
+  order is not observable in the response and no current behavior requires the
+  SQL ordering.
+- Highest-value follow-up: decide whether database row order is an intended
+  internal contract. If not, the clause is redundant production code rather
+  than a missing behavioral assertion.
 
-### S3 — replacement-index confirmation deletion
+### S3 — all-time heatmap `ORDER BY` deletion
 
-- Production: `database/migrations/EmailLogs.php:78`
-- Mutation: removed the `created_at_status` existence check before dropping the
-  legacy `status` index.
-- Full-suite result: survived; 33/33 smoke, 62/62 permissions, 48/48
+- Production: `app/Http/Controllers/DashboardController.php:79-81`
+- Mutation: removed the all-time query's weekday/hour ordering.
+- Full-suite result: survived; 33/33 smoke, 62/62 permissions, 58/58
   integration, zero skips, protected log count unchanged.
-- Gap: migration tests cover successful convergence and idempotence, but do not
-  force the replacement `ADD INDEX` to fail and prove the legacy status index
-  remains in place.
-- Highest-value follow-up: use a real incompatible pre-existing index state or
-  a fail-closed DDL query fixture, then assert that the legacy index is not
-  dropped after replacement creation fails.
+- Gap: as in S2, the response matrix has deterministic key order regardless of
+  the database row order.
+- Highest-value follow-up: resolve the same production-contract question as S2
+  before adding any SQL-shape assertion.
+
+### S4 — subject-count status predicate deletion
+
+- Production: `app/Models/Logger.php:535`
+- Mutation: replaced the status discriminator with a constant-true prepared
+  predicate while retaining all parameters.
+- Full-suite result: survived; 33/33 smoke, 62/62 permissions, 58/58
+  integration, zero skips, protected log count unchanged.
+- Gap: the strict aggregate fixture asks for sent subjects during January, but
+  its only failed subject is in March, so the date range masks deletion of the
+  status predicate.
+- Highest-value follow-up: place distinct sent and failed subjects inside the
+  same requested range and assert status-specific distinct-subject counts.
 
 ## Killed mutants
 
 | ID | Production mutation | Full-suite killer evidence |
 |---|---|---|
-| K1 | Removed the `created_at` predicate and its argument from `Logger::deleteLogsOlderThan()` (`app/Models/Logger.php:480`) | Integration failed on deleted count 5→8, retained rows 3→0, batch queries 3→5, the no-match row being deleted, and the site-local fixture deleting 2 instead of 1. |
-| K2 | Removed the `status` discriminator from both `Logger::getTotalCountStat()` branches (`app/Models/Logger.php:509,520`) | Dashboard Today counters changed from `[1,1]` to `[2,2]`; the open-ended failed count changed from 1 to 2. |
-| K3 | Reversed Gmail's expiry comparison (`app/Services/Mailer/Providers/Gmail/Handler.php:274`) | The rejected-grant case received a client instead of `WP_Error` and failed before the expected provider detail could be read. |
-| K4 | Removed the `created_at_status` existence guard before `ADD INDEX` (`database/migrations/EmailLogs.php:70`) | The idempotence case observed 2 `ALTER TABLE` statements instead of 0. |
+| M01 | Removed the report date-range predicate (`app/Services/Reporting.php:57`). | The new boundary case exposed both outside buckets and a total count of 3 instead of 1. |
+| M02 | Reversed Outlook's expiry comparison (`app/Services/Mailer/Providers/Outlook/Handler.php:215`). | The future-token case made one request instead of zero and returned a refreshed token; the expired case returned the stale cached token. |
+| M03 | Removed replacement-index confirmation before the legacy drop (`database/migrations/EmailLogs.php:78`). | The failed-ADD fixture observed one forbidden drop and the legacy `status` index disappeared. |
+| M04 | Removed the pruning retention predicate (`app/Models/Logger.php:480`). | Six assertions failed across bounded pruning, no-match pruning, and the site-local cutoff; newer rows were deleted. |
+| M05 | Removed the status discriminator from both total-count branches (`app/Models/Logger.php:509,520`). | Dashboard Today counters and the strict open-ended failed count included the wrong status. |
+| M06 | Reversed Gmail's expiry comparison (`app/Services/Mailer/Providers/Gmail/Handler.php:274`). | The rejected-grant handler case returned a client instead of the expected provider error. |
+| M07 | Removed the replacement-index existence guard before `ADD INDEX` (`database/migrations/EmailLogs.php:70`). | The idempotence case observed two `ALTER TABLE` statements instead of zero. |
+| M08 | Removed the report `GROUP BY` clause (`app/Services/Reporting.php:58`). | Twelve integration assertions failed across daily, weekly, monthly, strict-SQL, timezone, and whitelist behavior. |
+| M09 | Removed the report `ORDER BY` clause (`app/Services/Reporting.php:59`). | The whitelist-fallback case rejected the missing safe daily ordering. |
+| M10 | Removed the daily report date projection (`app/Services/Reporting.php:48`). | All three daily smoke variations reported an unknown `date` grouping column and seven integration assertions failed. |
+| M11 | Removed the daily report count projection (`app/Services/Reporting.php:48`). | Three smoke variations and four integration behaviors raised missing-count diagnostics; five value assertions also failed. |
+| M12 | Removed the bounded heatmap range predicate (`app/Http/Controllers/DashboardController.php:56`). | The lookback validation case no longer observed the clamped `INTERVAL 365 DAY` predicate. |
+| M15 | Removed the all-time heatmap `GROUP BY` clause (`app/Http/Controllers/DashboardController.php:76-78`). | Four timezone and strict-SQL assertions failed, including an `ONLY_FULL_GROUP_BY` database error. |
+| M17 | Removed the heatmap's upper 365-day clamp (`app/Http/Controllers/DashboardController.php:41`). | Both lookback-clamp assertions failed. |
+| M18 | Removed the pruning `LIMIT` clause (`app/Models/Logger.php:480`). | Five batch-count and fixed-batch SQL assertions failed. |
+| M19 | Removed pruning loop continuation (`app/Models/Logger.php:493`). | Seven assertions showed only the first batch was deleted and rows remained. |
 
-## Safety-fuse proof-of-catch
+## Closed survivors from the previous audit
 
-The new CLI pruning case runs `prune-logs --days=1 --yes`, asserts the child
-process reports that the production-log `DELETE` was fused, expects zero
-deletions, and compares protected row counts. Changing only the child fixture's
-fuse marker made the owning integration case fail with:
-
-> child process did not prove the production-log write fuse
-
-The marker was restored and the filtered CLI tier returned 4/4 green before
-the mutation audit began.
+The previous 48-case audit's three survivors are M01-M03 above. Each is now
+killed by its stated follow-up, and each follow-up has an isolated
+proof-of-catch commit on this branch.

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,7 @@ bash tests/bin/run-all.sh static
 bash tests/bin/run-all.sh smoke
 bash tests/bin/run-all.sh permissions
 bash tests/bin/run-all.sh integration
+bash tests/bin/run-coverage.sh
 ```
 
 The harness forces FluentSMTP's Simulator provider, blocks outbound HTTP, and
@@ -27,6 +28,10 @@ REST route.
 Runtime prefix portability was verified on 2026-08-04 by running the full suite
 against an isolated WordPress install with the `wptest_` table prefix. Set
 `FSMTP_WP_ROOT` to exercise the suite against a different local install.
+
+The optional coverage gate uses PCOV to merge smoke, permission, and integration
+line maps. It fails until every production PHP file over 100 lines with zero
+hits has a current decision in `tests/coverage/zero-coverage-triage.php`.
 
 ## Phase 6 — shared-table isolation
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,7 @@ bash tests/bin/run-all.sh static
 bash tests/bin/run-all.sh smoke
 bash tests/bin/run-all.sh permissions
 bash tests/bin/run-all.sh integration
+bash tests/bin/run-all.sh js
 bash tests/bin/run-environment-axes.sh
 bash tests/bin/run-coverage.sh
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,24 @@
+# FluentSMTP local test suite
+
+This suite runs through WP-CLI against the local development WordPress install.
+It does not use Docker, PHPUnit, `wp-env`, or a CI service.
+
+```bash
+bash tests/bin/run-all.sh
+bash tests/bin/run-all.sh static
+bash tests/bin/run-all.sh smoke
+bash tests/bin/run-all.sh permissions
+bash tests/bin/run-all.sh integration
+```
+
+The harness forces FluentSMTP's Simulator provider, blocks outbound HTTP, and
+fails if the real `fsmpt_email_logs` row count changes during a run. Read
+`tests/AGENT.md` before adding cases.
+
+The admin application uses admin-AJAX. Its 42-route manifest (11 GET and 31
+POST) lives at `tests/smoke/routes.manifest.php`; only the Outlook callback is a
+REST route.
+
+Current environment limitation: this install has the default `wp_` WordPress
+table prefix, so runtime non-default-prefix coverage must be performed on a
+separate suitable install.

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,7 @@ bash tests/bin/run-all.sh static
 bash tests/bin/run-all.sh smoke
 bash tests/bin/run-all.sh permissions
 bash tests/bin/run-all.sh integration
+bash tests/bin/run-environment-axes.sh
 bash tests/bin/run-coverage.sh
 ```
 
@@ -28,6 +29,12 @@ REST route.
 Runtime prefix portability was verified on 2026-08-04 by running the full suite
 against an isolated WordPress install with the `wptest_` table prefix. Set
 `FSMTP_WP_ROOT` to exercise the suite against a different local install.
+
+The phase-20 environment runner executes the complete suite at numeric timezone
+offsets `+6` and `-8`, then once more with `ONLY_FULL_GROUP_BY` and
+`STRICT_TRANS_TABLES`. These are process-local option filters and SQL session
+modes; neither WordPress install's saved timezone or database configuration is
+changed.
 
 The optional coverage gate uses PCOV to merge smoke, permission, and integration
 line maps. It fails until every production PHP file over 100 lines with zero

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,3 +22,11 @@ REST route.
 Current environment limitation: this install has the default `wp_` WordPress
 table prefix, so runtime non-default-prefix coverage must be performed on a
 separate suitable install.
+
+## Phase 6 — shared-table isolation
+
+Not applicable. FluentSMTP owns one plugin table,
+`{$wpdb->prefix}fsmpt_email_logs`, and its rows have no site, tenant, account,
+or other shared-table discriminator. Prefix safety is covered by the static SQL
+gate and by resolving the table through `$wpdb->prefix`; the remaining runtime
+non-default-prefix check is the environment limitation above.

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,14 +24,14 @@ The admin application uses admin-AJAX. Its 42-route manifest (11 GET and 31
 POST) lives at `tests/smoke/routes.manifest.php`; only the Outlook callback is a
 REST route.
 
-Current environment limitation: this install has the default `wp_` WordPress
-table prefix, so runtime non-default-prefix coverage must be performed on a
-separate suitable install.
+Runtime prefix portability was verified on 2026-08-04 by running the full suite
+against an isolated WordPress install with the `wptest_` table prefix. Set
+`FSMTP_WP_ROOT` to exercise the suite against a different local install.
 
 ## Phase 6 — shared-table isolation
 
 Not applicable. FluentSMTP owns one plugin table,
 `{$wpdb->prefix}fsmpt_email_logs`, and its rows have no site, tenant, account,
 or other shared-table discriminator. Prefix safety is covered by the static SQL
-gate and by resolving the table through `$wpdb->prefix`; the remaining runtime
-non-default-prefix check is the environment limitation above.
+gate, by resolving the table through `$wpdb->prefix`, and by the isolated
+`wptest_` runtime suite described above.

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,11 @@ The harness forces FluentSMTP's Simulator provider, blocks outbound HTTP, and
 fails if the real `fsmpt_email_logs` row count changes during a run. Read
 `tests/AGENT.md` before adding cases.
 
+The integration tier also launches fresh child processes for the real
+`wp fluent-smtp test`, `health`, `stats`, and `prune-logs` commands. The child
+bootstrap independently proves Simulator resolution and fuses logging, HTTP,
+cron scheduling, and health-report option writes.
+
 The admin application uses admin-AJAX. Its 42-route manifest (11 GET and 31
 POST) lives at `tests/smoke/routes.manifest.php`; only the Outlook callback is a
 REST route.

--- a/tests/bin/cli-bootstrap.php
+++ b/tests/bin/cli-bootstrap.php
@@ -37,6 +37,27 @@ WP_CLI::add_hook('after_wp_load', function () use ($suiteSettings) {
         return false;
     }, PHP_INT_MAX, 3);
     add_filter('fluentmail_will_log_email', '__return_false', PHP_INT_MAX);
+    add_filter('query', function ($query) {
+        global $wpdb;
+
+        $table = $wpdb->prefix . FLUENT_MAIL_DB_PREFIX . 'email_logs';
+        $deletePattern = '/^\s*DELETE\s+FROM\s+`?'
+            . preg_quote($table, '/') . '`?(?:\s|$)/i';
+        if (!preg_match($deletePattern, $query)) {
+            return $query;
+        }
+
+        // Child CLI coverage is allowed to reach the real pruning command, but
+        // no test subprocess is allowed to change a production log row. Insert
+        // the impossible predicate before LIMIT for both healthy and mutated SQL.
+        $limitOffset = stripos($query, ' LIMIT ');
+        $head = $limitOffset === false ? $query : substr($query, 0, $limitOffset);
+        $tail = $limitOffset === false ? '' : substr($query, $limitOffset);
+        $predicate = stripos($head, ' WHERE ') === false ? ' WHERE 1 = 0' : ' AND 1 = 0';
+
+        WP_CLI::log('FluentSMTP CLI safety: production log DELETE fused.');
+        return $head . $predicate . $tail;
+    }, PHP_INT_MAX);
     add_filter('pre_http_request', function ($preempt, $args, $url) {
         return new WP_Error(
             'fsmtp_cli_test_http_blocked',

--- a/tests/bin/cli-bootstrap.php
+++ b/tests/bin/cli-bootstrap.php
@@ -1,0 +1,57 @@
+<?php
+/** Safety bootstrap loaded by every WP-CLI subprocess integration case. */
+
+if (!defined('FLUENTMAIL_SIMULATE_EMAILS')) {
+    define('FLUENTMAIL_SIMULATE_EMAILS', true);
+}
+if (!defined('FLUENTMAIL_LOG_OFF')) {
+    define('FLUENTMAIL_LOG_OFF', true);
+}
+
+if (!class_exists('WP_CLI')) {
+    throw new RuntimeException('The FluentSMTP CLI safety bootstrap requires WP-CLI.');
+}
+
+$encodedSettings = getenv('FSMTP_SUITE_SETTINGS_B64');
+$decodedSettings = $encodedSettings ? base64_decode($encodedSettings, true) : false;
+$suiteSettings = $decodedSettings === false ? null : json_decode($decodedSettings, true);
+
+if (!is_array($suiteSettings)) {
+    WP_CLI::error('FluentSMTP CLI suite settings are missing or invalid.');
+}
+
+WP_CLI::add_hook('after_wp_load', function () use ($suiteSettings) {
+    add_filter('pre_option_fluentmail-settings', function () use ($suiteSettings) {
+        return $suiteSettings;
+    }, PHP_INT_MAX);
+
+    // Health must be isolated from both an old report and persistent writes.
+    add_filter('pre_option__fluentsmtp_connection_health', function () {
+        return [];
+    }, PHP_INT_MAX);
+    add_filter('pre_update_option__fluentsmtp_connection_health', function ($newValue, $oldValue) {
+        return $oldValue;
+    }, PHP_INT_MAX, 2);
+
+    add_filter('pre_schedule_event', function () {
+        return false;
+    }, PHP_INT_MAX, 3);
+    add_filter('fluentmail_will_log_email', '__return_false', PHP_INT_MAX);
+    add_filter('pre_http_request', function ($preempt, $args, $url) {
+        return new WP_Error(
+            'fsmtp_cli_test_http_blocked',
+            'Outbound HTTP blocked by the FluentSMTP CLI suite: ' . strtok((string)$url, '?')
+        );
+    }, PHP_INT_MAX, 3);
+
+    if (!function_exists('fluentMailGetProvider')) {
+        WP_CLI::error('FluentSMTP is not active in the CLI child process.');
+    }
+
+    $provider = fluentMailGetProvider('fsmtp-cli-safety@example.test', true);
+    if (!$provider instanceof \FluentMail\App\Services\Mailer\Providers\Simulator\Handler) {
+        WP_CLI::error('FluentSMTP CLI safety check did not resolve the Simulator provider.');
+    }
+
+    WP_CLI::log('FluentSMTP CLI safety: Simulator active.');
+});

--- a/tests/bin/coverage-bootstrap.php
+++ b/tests/bin/coverage-bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+/** Start PCOV as PHP's auto-prepend file, before WP-CLI and WordPress load. */
+
+if ((string) getenv('FSMTP_COVERAGE_FILE') !== '') {
+    if (!function_exists('pcov\\start') || ini_get('pcov.enabled') !== '1') {
+        throw new RuntimeException('Coverage bootstrap requires pcov.enabled=1.');
+    }
+
+    \pcov\clear();
+    \pcov\start();
+    define('FSMTP_COVERAGE_STARTED_EARLY', true);
+}

--- a/tests/bin/coverage-triage.php
+++ b/tests/bin/coverage-triage.php
@@ -1,0 +1,115 @@
+<?php
+/** Fail when a production PHP file over 100 lines has zero hits and no triage. */
+
+$root = dirname(__DIR__, 2);
+$coverageDir = isset($argv[1]) ? $argv[1] : '';
+$triageFile = $root . '/tests/coverage/zero-coverage-triage.php';
+
+if (!$coverageDir || !is_dir($coverageDir)) {
+    fwrite(STDERR, "coverage-triage: pass the PCOV data directory\n");
+    exit(2);
+}
+
+$coverage = [];
+$files = glob(rtrim($coverageDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*.json');
+foreach ($files ?: [] as $file) {
+    $decoded = json_decode((string) file_get_contents($file), true);
+    if (!is_array($decoded)) {
+        fwrite(STDERR, "coverage-triage: invalid coverage file " . basename($file) . "\n");
+        exit(2);
+    }
+
+    foreach ($decoded as $path => $lines) {
+        foreach ((array) $lines as $line => $status) {
+            $coverage[$path][(int) $line] = max(
+                isset($coverage[$path][(int) $line]) ? $coverage[$path][(int) $line] : -1,
+                (int) $status
+            );
+        }
+    }
+}
+
+if (count($files ?: []) !== 3) {
+    fwrite(STDERR, "coverage-triage: expected smoke, permissions, and integration PCOV files\n");
+    exit(2);
+}
+
+$eligible = [];
+foreach (['app', 'includes', 'database'] as $directory) {
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root . '/' . $directory, FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($iterator as $fileInfo) {
+        $path = str_replace(DIRECTORY_SEPARATOR, '/', substr($fileInfo->getPathname(), strlen($root) + 1));
+        if (!$fileInfo->isFile() || $fileInfo->getExtension() !== 'php') {
+            continue;
+        }
+        if (strpos('/' . $path . '/', '/vendor/') !== false || strpos('/' . $path . '/', '/libs/') !== false) {
+            continue;
+        }
+
+        $lineCount = count(file($fileInfo->getPathname()));
+        if ($lineCount > 100) {
+            $eligible[$path] = $lineCount;
+        }
+    }
+}
+ksort($eligible);
+
+$zero = [];
+foreach ($eligible as $path => $lineCount) {
+    $hits = array_filter(isset($coverage[$path]) ? $coverage[$path] : [], function ($status) {
+        return $status > 0;
+    });
+    if (!$hits) {
+        $zero[$path] = $lineCount;
+    }
+}
+
+$triage = is_file($triageFile) ? require $triageFile : [];
+if (!is_array($triage)) {
+    fwrite(STDERR, "coverage-triage: triage file must return an array\n");
+    exit(2);
+}
+
+$errors = [];
+foreach ($zero as $path => $lineCount) {
+    if (!isset($triage[$path])) {
+        $errors[] = "untriaged zero-coverage file: {$path} ({$lineCount} lines)";
+        continue;
+    }
+    foreach (['category', 'reason', 'next'] as $field) {
+        if (empty($triage[$path][$field]) || !is_string($triage[$path][$field])) {
+            $errors[] = "{$path} triage is missing {$field}";
+        }
+    }
+}
+foreach ($triage as $path => $details) {
+    if (!isset($zero[$path])) {
+        $errors[] = "stale zero-coverage triage: {$path}";
+    }
+}
+
+echo sprintf(
+    "coverage-triage: %d production PHP files over 100 lines; %d hit, %d at zero, %d triaged\n",
+    count($eligible),
+    count($eligible) - count($zero),
+    count($zero),
+    count(array_intersect_key($triage, $zero))
+);
+
+foreach ($zero as $path => $lineCount) {
+    $category = isset($triage[$path]['category']) ? $triage[$path]['category'] : 'UNTRIAGED';
+    echo "  ZERO {$path} ({$lineCount} lines) — {$category}\n";
+}
+
+if ($errors) {
+    echo "\nFAIL — coverage triage is incomplete:\n";
+    foreach ($errors as $error) {
+        echo "  - {$error}\n";
+    }
+    exit(1);
+}
+
+echo "OK — every >100-line production PHP file at zero coverage is triaged.\n";
+exit(0);

--- a/tests/bin/lib/resolve-wp-root.sh
+++ b/tests/bin/lib/resolve-wp-root.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Resolve WordPress without hardcoding this development machine's layout.
+
+fsmtp_resolve_wp_root() {
+  local plugin_dir="$1"
+  local dir abspath
+
+  if [ -n "${FSMTP_WP_ROOT:-}" ]; then
+    if [ ! -f "$FSMTP_WP_ROOT/wp-load.php" ]; then
+      echo "FSMTP_WP_ROOT is set to '$FSMTP_WP_ROOT' but no wp-load.php is there." >&2
+      return 2
+    fi
+    printf '%s\n' "${FSMTP_WP_ROOT%/}"
+    return 0
+  fi
+
+  dir="$plugin_dir"
+  while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+    if [ -f "$dir/wp-load.php" ]; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+
+  if command -v wp >/dev/null 2>&1; then
+    abspath="$(cd "$plugin_dir" && wp eval 'echo untrailingslashit(ABSPATH);' \
+      --skip-plugins --skip-themes 2>/dev/null | tail -n 1)"
+    if [ -n "$abspath" ] && [ -f "$abspath/wp-load.php" ]; then
+      printf '%s\n' "$abspath"
+      return 0
+    fi
+  fi
+
+  echo "Could not locate the WordPress root from '$plugin_dir'." >&2
+  echo "Set it explicitly: export FSMTP_WP_ROOT=/path/to/wordpress" >&2
+  return 2
+}

--- a/tests/bin/run-all.sh
+++ b/tests/bin/run-all.sh
@@ -80,6 +80,20 @@ run_wp_suite() {
   echo
 }
 
+run_js() {
+  echo "${BOLD}S4 — admin request layer${OFF}"; hr
+  if ! command -v pnpm >/dev/null 2>&1; then
+    echo "${RED}pnpm not found on PATH.${OFF}"
+    record "S4 — admin request layer" 1
+    echo
+    return
+  fi
+
+  ( cd "$PLUGIN_DIR" && pnpm test:js )
+  record "S4 — admin request layer" $?
+  echo
+}
+
 if ! command -v wp >/dev/null 2>&1; then
   echo "${RED}wp-cli not found on PATH.${OFF}"; exit 2
 fi
@@ -103,8 +117,10 @@ case "$SUITE" in
   integration)
     run_wp_suite "S2/S3 — integration" "tests/bin/run-integration.php"
     ;;
+  js) run_js ;;
   all)
     run_static
+    run_js
     run_wp_suite "S1 — admin-AJAX smoke" "tests/bin/run-smoke.php"
     if [ -f "$PLUGIN_DIR/tests/smoke/mutating.manifest.php" ]; then
       run_wp_suite "S1 — permission smoke" "tests/bin/run-permissions.php"
@@ -118,7 +134,7 @@ case "$SUITE" in
     fi
     ;;
   *)
-    echo "Unknown suite: $SUITE (use: static|smoke|permissions|integration|all)"
+    echo "Unknown suite: $SUITE (use: static|smoke|permissions|integration|js|all)"
     exit 2
     ;;
 esac

--- a/tests/bin/run-all.sh
+++ b/tests/bin/run-all.sh
@@ -54,6 +54,11 @@ run_static() {
     record "lint: route-coverage" $?
   fi
 
+  if [ -f "$PLUGIN_DIR/tests/lint/browser-route-coverage.php" ]; then
+    php "$PLUGIN_DIR/tests/lint/browser-route-coverage.php"
+    record "lint: browser-route-coverage" $?
+  fi
+
   php "$PLUGIN_DIR/tests/lint/raw-sql-prefix.php" "$PLUGIN_DIR/tests/lint/fixtures" >/dev/null 2>&1
   if [ $? -eq 1 ]; then
     echo "lint self-test: raw-sql-prefix still fires on fixtures"

--- a/tests/bin/run-all.sh
+++ b/tests/bin/run-all.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# FluentSMTP local test runner. No Docker, CI service, wp-env, or PHPUnit.
+
+set -uo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+. "$PLUGIN_DIR/tests/bin/lib/resolve-wp-root.sh"
+WP_ROOT="$(fsmtp_resolve_wp_root "$PLUGIN_DIR")" || exit 2
+SUITE="${1:-all}"
+
+RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; BOLD=$'\033[1m'; OFF=$'\033[0m'
+FAILED=0
+declare -a RESULTS=()
+
+hr() { printf '%s\n' "------------------------------------------------------------------------"; }
+
+record() {
+  if [ "$2" -eq 0 ]; then
+    RESULTS+=("${GREEN}PASS${OFF}  $1")
+  else
+    RESULTS+=("${RED}FAIL${OFF}  $1")
+    FAILED=1
+  fi
+}
+
+read_log_count() {
+  ( cd "$WP_ROOT" && wp eval 'global $wpdb; echo (int) $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}fsmpt_email_logs");' 2>/dev/null )
+}
+
+RUN_LOG_COUNT_BEFORE="$(read_log_count)"
+if ! [[ "$RUN_LOG_COUNT_BEFORE" =~ ^[0-9]+$ ]]; then
+  echo "${RED}Could not record the protected FluentSMTP log count before the run.${OFF}"
+  exit 2
+fi
+
+run_static() {
+  echo "${BOLD}S0 — static gates${OFF}"; hr
+
+  local syntax_errors
+  syntax_errors=$(find "$PLUGIN_DIR/app" "$PLUGIN_DIR/includes" "$PLUGIN_DIR/database" -name '*.php' \
+    -not -path '*/vendor/*' -not -path '*/libs/*' \
+    -exec php -l {} \; 2>&1 | grep -E '^(Parse|Fatal) error' || true)
+  if [ -n "$syntax_errors" ]; then
+    echo "$syntax_errors"; record "php -l" 1
+  else
+    echo "php -l: clean"; record "php -l" 0
+  fi
+
+  php "$PLUGIN_DIR/tests/lint/raw-sql-prefix.php"
+  record "lint: raw-sql-prefix" $?
+
+  if [ -f "$PLUGIN_DIR/tests/lint/route-coverage.php" ]; then
+    php "$PLUGIN_DIR/tests/lint/route-coverage.php"
+    record "lint: route-coverage" $?
+  fi
+
+  php "$PLUGIN_DIR/tests/lint/raw-sql-prefix.php" "$PLUGIN_DIR/tests/lint/fixtures" >/dev/null 2>&1
+  if [ $? -eq 1 ]; then
+    echo "lint self-test: raw-sql-prefix still fires on fixtures"
+    record "lint self-test" 0
+  else
+    echo "${RED}lint self-test FAILED — raw-sql-prefix no longer catches its fixture${OFF}"
+    record "lint self-test" 1
+  fi
+  echo
+}
+
+run_wp_suite() {
+  echo "${BOLD}$1${OFF}"; hr
+  ( cd "$WP_ROOT" && wp eval-file "$PLUGIN_DIR/$2" 2>&1 ) \
+    | grep -vE '^(Notice|Deprecated|Warning): ' \
+    | grep -vE '^<div id="error">'
+  local code=${PIPESTATUS[0]}
+  record "$1" "$code"
+  echo
+}
+
+if ! command -v wp >/dev/null 2>&1; then
+  echo "${RED}wp-cli not found on PATH.${OFF}"; exit 2
+fi
+if [ ! -d "$WP_ROOT" ]; then
+  echo "${RED}WordPress root not found: $WP_ROOT${OFF}"; exit 2
+fi
+
+echo
+echo "${BOLD}FluentSMTP test run${OFF}  (suite: $SUITE)"
+echo "plugin: $PLUGIN_DIR"
+echo "wp:     $WP_ROOT"
+echo "logs:   $RUN_LOG_COUNT_BEFORE before run"
+echo
+
+case "$SUITE" in
+  static) run_static ;;
+  smoke) run_wp_suite "S1 — admin-AJAX smoke" "tests/bin/run-smoke.php" ;;
+  permissions)
+    run_wp_suite "S1 — permission smoke" "tests/bin/run-permissions.php"
+    ;;
+  integration)
+    run_wp_suite "S2/S3 — integration" "tests/bin/run-integration.php"
+    ;;
+  all)
+    run_static
+    run_wp_suite "S1 — admin-AJAX smoke" "tests/bin/run-smoke.php"
+    if [ -f "$PLUGIN_DIR/tests/smoke/mutating.manifest.php" ]; then
+      run_wp_suite "S1 — permission smoke" "tests/bin/run-permissions.php"
+    else
+      echo "${YELLOW}S1 — permission smoke: phase not built yet, skipping${OFF}"; echo
+    fi
+    if find "$PLUGIN_DIR/tests/integration" -maxdepth 1 -name '*.php' -print -quit | grep -q .; then
+      run_wp_suite "S2/S3 — integration" "tests/bin/run-integration.php"
+    else
+      echo "${YELLOW}S2/S3 — integration: phase not built yet, skipping${OFF}"; echo
+    fi
+    ;;
+  *)
+    echo "Unknown suite: $SUITE (use: static|smoke|permissions|integration|all)"
+    exit 2
+    ;;
+esac
+
+RUN_LOG_COUNT_AFTER="$(read_log_count)"
+if [ "$RUN_LOG_COUNT_AFTER" != "$RUN_LOG_COUNT_BEFORE" ]; then
+  echo "${RED}FAIL — protected fsmpt_email_logs count drifted from $RUN_LOG_COUNT_BEFORE to $RUN_LOG_COUNT_AFTER.${OFF}"
+  record "protected log count" 1
+else
+  echo "protected log count: unchanged at $RUN_LOG_COUNT_AFTER"
+  record "protected log count" 0
+fi
+
+hr
+echo "${BOLD}SUMMARY${OFF}"
+for result in "${RESULTS[@]}"; do echo "  $result"; done
+hr
+
+exit "$FAILED"

--- a/tests/bin/run-coverage.sh
+++ b/tests/bin/run-coverage.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Collect PCOV data from all runtime tiers and enforce the Phase 13 zero-file triage.
+
+set -uo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+. "$PLUGIN_DIR/tests/bin/lib/resolve-wp-root.sh"
+WP_ROOT="$(fsmtp_resolve_wp_root "$PLUGIN_DIR")" || exit 2
+PHP_BIN="${FSMTP_PHP_BIN:-$(command -v php)}"
+WP_BIN="$(command -v wp)"
+COVERAGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fsmtp-coverage.XXXXXX")"
+FAILED=0
+
+cleanup() {
+  if [[ "$COVERAGE_DIR" == "${TMPDIR:-/tmp}/fsmtp-coverage."* && -d "$COVERAGE_DIR" ]]; then
+    rm -rf -- "$COVERAGE_DIR"
+  fi
+}
+trap cleanup EXIT
+
+if [ -z "$PHP_BIN" ] || [ -z "$WP_BIN" ]; then
+  echo "coverage: php and wp must both be available on PATH" >&2
+  exit 2
+fi
+
+run_tier() {
+  local name="$1"
+  local runner="$2"
+  echo "coverage: running $name"
+  if ! FSMTP_COVERAGE_FILE="$COVERAGE_DIR/$name.json" \
+      "$PHP_BIN" -d pcov.enabled=1 -d pcov.directory="$PLUGIN_DIR" \
+      -d auto_prepend_file="$PLUGIN_DIR/tests/bin/coverage-bootstrap.php" \
+      "$WP_BIN" \
+      --path="$WP_ROOT" eval-file "$PLUGIN_DIR/$runner"; then
+    FAILED=1
+  fi
+}
+
+run_tier smoke tests/bin/run-smoke.php
+run_tier permissions tests/bin/run-permissions.php
+run_tier integration tests/bin/run-integration.php
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "coverage: a runtime tier failed; triage was not evaluated" >&2
+  exit 1
+fi
+
+"$PHP_BIN" "$PLUGIN_DIR/tests/bin/coverage-triage.php" "$COVERAGE_DIR"

--- a/tests/bin/run-environment-axes.sh
+++ b/tests/bin/run-environment-axes.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Phase 20: rerun the complete suite with non-default clocks and strict MySQL.
+
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+for offset in 6 -8; do
+  printf '\nFluentSMTP environment axis: gmt_offset=%s\n' "$offset"
+  FSMTP_TEST_GMT_OFFSET="$offset" bash "$PLUGIN_DIR/tests/bin/run-all.sh"
+done
+
+printf '\nFluentSMTP environment axis: ONLY_FULL_GROUP_BY + STRICT_TRANS_TABLES\n'
+FSMTP_TEST_STRICT_SQL=1 bash "$PLUGIN_DIR/tests/bin/run-all.sh"

--- a/tests/bin/run-integration.php
+++ b/tests/bin/run-integration.php
@@ -1,0 +1,74 @@
+<?php
+/** FluentSMTP integration runner for database-backed behavior cases. */
+
+require_once dirname(__DIR__) . '/lib/harness.php';
+require_once dirname(__DIR__) . '/lib/factory.php';
+
+FsmtpTest::boot();
+FsmtpTest::interceptHttp();
+$adminId = get_current_user_id();
+
+$files = glob(dirname(__DIR__) . '/integration/*.php');
+$files = $files === false ? [] : $files;
+sort($files);
+
+$requested = [];
+foreach ((array) $args as $argument) {
+    if (strpos($argument, '--filter=') === 0) {
+        $value = substr($argument, 9);
+    } elseif (strpos($argument, 'filter=') === 0) {
+        $value = substr($argument, 7);
+    } else {
+        continue;
+    }
+    $requested = array_values(array_filter(array_map('trim', explode(',', $value))));
+}
+if ($requested) {
+    $files = array_values(array_filter($files, function ($file) use ($requested) {
+        return in_array(basename($file), $requested, true);
+    }));
+}
+
+WP_CLI::log(sprintf(
+    "FluentSMTP integration — %d files%s\n",
+    count($files),
+    $requested ? ' (filtered)' : ''
+));
+
+$cleanup = function () {
+    try {
+        FsmtpFactory::cleanup();
+        FsmtpFactory::cleanup();
+    } catch (Throwable $e) {
+        WP_CLI::warning('Fixture cleanup failed: ' . $e->getMessage());
+    }
+};
+register_shutdown_function($cleanup);
+
+if (!$files) {
+    FsmtpTest::case('integration runner discovers test files', function () {
+        FsmtpTest::fail('No tests/integration/*.php files were found.');
+    });
+}
+
+try {
+    foreach ($files as $file) {
+        try {
+            wp_set_current_user($adminId);
+            $suite = require $file;
+            if (!is_callable($suite)) {
+                throw new RuntimeException(basename($file) . ' must return a callable.');
+            }
+            $suite();
+        } catch (Throwable $e) {
+            FsmtpTest::case('integration file loads: ' . basename($file), function () use ($e) {
+                throw $e;
+            });
+        }
+    }
+} finally {
+    wp_set_current_user($adminId);
+    $cleanup();
+}
+
+FsmtpTest::finish('INTEGRATION');

--- a/tests/bin/run-permissions.php
+++ b/tests/bin/run-permissions.php
@@ -14,16 +14,7 @@ FsmtpTest::boot();
 FsmtpTest::interceptHttp();
 
 $manifest = require dirname(__DIR__) . '/smoke/mutating.manifest.php';
-$knownFailures = [
-    'settings/telegram/send-test' => 'TelegramController.php:116 sendTestMessage() does not call verify()',
-    'settings/telegram/disconnect' => 'TelegramController.php:141 disconnect() does not call verify()',
-    'settings/slack/send-test' => 'SlackController.php:58 sendTestMessage() does not call verify()',
-    'settings/slack/disconnect' => 'SlackController.php:85 disconnect() does not call verify()',
-    'settings/discord/send-test' => 'DiscordController.php:50 sendTestMessage() does not call verify()',
-    'settings/discord/disconnect' => 'DiscordController.php:78 disconnect() does not call verify()',
-    'settings/pushover/send-test' => 'PushoverController.php:41 sendTestMessage() does not call verify()',
-    'settings/pushover/disconnect' => 'PushoverController.php:69 disconnect() does not call verify()',
-];
+$knownFailures = [];
 
 $protectedOptions = [
     'fluentmail-settings',

--- a/tests/bin/run-permissions.php
+++ b/tests/bin/run-permissions.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Phase 3 — permission smoke for all 31 mutating admin-AJAX routes.
+ *
+ * Anonymous coverage verifies that no nopriv action exists. Low-privilege
+ * coverage dispatches each real wp_ajax callback as a temporary subscriber.
+ * Option writes are fused, HTTP is intercepted, inert IDs are used, and every
+ * case runs in a rolled-back transaction as a final safety net.
+ */
+
+require_once dirname(__DIR__) . '/lib/harness.php';
+
+FsmtpTest::boot();
+FsmtpTest::interceptHttp();
+
+$manifest = require dirname(__DIR__) . '/smoke/mutating.manifest.php';
+$knownFailures = [
+    'settings/telegram/send-test' => 'TelegramController.php:116 sendTestMessage() does not call verify()',
+    'settings/telegram/disconnect' => 'TelegramController.php:141 disconnect() does not call verify()',
+    'settings/slack/send-test' => 'SlackController.php:58 sendTestMessage() does not call verify()',
+    'settings/slack/disconnect' => 'SlackController.php:85 disconnect() does not call verify()',
+    'settings/discord/send-test' => 'DiscordController.php:50 sendTestMessage() does not call verify()',
+    'settings/discord/disconnect' => 'DiscordController.php:78 disconnect() does not call verify()',
+    'settings/pushover/send-test' => 'PushoverController.php:41 sendTestMessage() does not call verify()',
+    'settings/pushover/disconnect' => 'PushoverController.php:69 disconnect() does not call verify()',
+];
+
+$protectedOptions = [
+    'fluentmail-settings',
+    '_fluent_smtp_notify_settings',
+    '_fluentsmtp_sub_update',
+    '_fluentsmtp_dismissed_timestamp',
+    '_fluentsmtp_intended_outlook_info',
+    '_fluentmail_last_generated_state',
+    'active_plugins',
+];
+
+/** Read exact database option rows, bypassing the object cache. */
+$readOptions = function () use ($protectedOptions) {
+    global $wpdb;
+    $snapshot = [];
+    foreach ($protectedOptions as $name) {
+        $row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT option_value, autoload FROM {$wpdb->options} WHERE option_name = %s",
+                $name
+            ),
+            ARRAY_A
+        );
+        $snapshot[$name] = $row ?: null;
+    }
+    return $snapshot;
+};
+
+/** Clear option caches after a transaction rollback. */
+$clearOptionCaches = function () use ($protectedOptions) {
+    foreach ($protectedOptions as $name) {
+        wp_cache_delete($name, 'options');
+    }
+    wp_cache_delete('alloptions', 'options');
+    wp_cache_delete('notoptions', 'options');
+};
+
+// Returning the old value stops every known FluentSMTP/activation option write
+// before SQL. The transaction below remains as a backstop for an unknown write.
+$optionFuses = [];
+foreach ($protectedOptions as $name) {
+    $callback = function ($newValue, $oldValue) {
+        return $oldValue;
+    };
+    add_filter('pre_update_option_' . $name, $callback, PHP_INT_MAX, 2);
+    $optionFuses[$name] = $callback;
+}
+
+$adminId = get_current_user_id();
+$username = FsmtpTest::uniq('fsmtp-permission');
+$subscriberId = wp_insert_user([
+    'user_login' => $username,
+    'user_pass'  => wp_generate_password(24, true, true),
+    'user_email' => $username . '@example.test',
+    'role'       => 'subscriber',
+]);
+if (is_wp_error($subscriberId)) {
+    WP_CLI::error('Could not create permission subscriber: ' . $subscriberId->get_error_message());
+}
+
+$cleanup = function () use ($adminId, $subscriberId, $optionFuses) {
+    wp_set_current_user($adminId);
+    foreach ($optionFuses as $name => $callback) {
+        remove_filter('pre_update_option_' . $name, $callback, PHP_INT_MAX);
+    }
+    if (!function_exists('wp_delete_user')) {
+        require_once ABSPATH . 'wp-admin/includes/user.php';
+    }
+    if (get_user_by('ID', $subscriberId)) {
+        wp_delete_user($subscriberId);
+    }
+};
+register_shutdown_function($cleanup);
+
+WP_CLI::log(sprintf(
+    "FluentSMTP permissions — %d POST routes, anonymous + subscriber\n",
+    count($manifest)
+));
+
+try {
+    foreach ($manifest as $entry) {
+        $route = $entry['route'];
+        $params = $entry['cases'][0]['params'];
+
+        FsmtpTest::case('POST ' . $route . ' — anonymous', function () use ($route) {
+            $adminHook = FsmtpTest::ajaxAction('POST', $route, true);
+            $publicHook = FsmtpTest::ajaxAction('POST', $route, false);
+
+            FsmtpTest::assert(
+                has_action($adminHook) !== false,
+                'admin callback is not registered: ' . $adminHook
+            );
+            FsmtpTest::assert(
+                has_action($publicHook) === false,
+                'SECURITY: anonymous callback is registered: ' . $publicHook
+            );
+        });
+
+        FsmtpTest::case('POST ' . $route . ' — subscriber', function () use (
+            $route,
+            $params,
+            $subscriberId,
+            $knownFailures,
+            $readOptions,
+            $clearOptionCaches
+        ) {
+            global $wpdb;
+
+            wp_set_current_user($subscriberId);
+            $before = $readOptions();
+            $wpdb->query('START TRANSACTION');
+
+            try {
+                $result = FsmtpTest::ajax('POST', $route, $params);
+            } finally {
+                $wpdb->query('ROLLBACK');
+                $clearOptionCaches();
+            }
+
+            $after = $readOptions();
+            FsmtpTest::assertSame($before, $after, 'permission safety fuses preserved protected options');
+
+            if ($result['db_error'] !== '') {
+                FsmtpTest::fail('DATABASE ERROR during permission check: ' . $result['db_error']);
+                return;
+            }
+
+            $message = FsmtpTest::ajaxMessage($result);
+            $denied = is_array($result['data'])
+                && isset($result['data']['success'])
+                && $result['data']['success'] === false
+                && stripos($message, 'permission') !== false;
+
+            if ($denied) {
+                return;
+            }
+
+            if (isset($knownFailures[$route]) && getenv('FSMTP_STRICT_KNOWN_FAILURES') !== '1') {
+                FsmtpTest::skip(
+                    'KNOWN-FAILURE: permission bypass — ' . $knownFailures[$route]
+                    . '; observed response: ' . ($message !== '' ? $message : '(no message)')
+                );
+                return;
+            }
+
+            FsmtpTest::fail(
+                (isset($knownFailures[$route]) ? 'KNOWN-FAILURE: ' : '')
+                . 'SECURITY: subscriber was not rejected by Controller::verify()'
+                . "\n  action: " . $result['action']
+                . "\n  response message: " . ($message !== '' ? $message : '(no message)')
+            );
+        });
+    }
+} finally {
+    $cleanup();
+}
+
+FsmtpTest::finish('PERMISSIONS');

--- a/tests/bin/run-smoke.php
+++ b/tests/bin/run-smoke.php
@@ -129,6 +129,27 @@ foreach ($getRoutes as $entry) {
 
             $params = $replaceTokens($variation['params']);
             $result = FsmtpTest::ajax($entry['method'], $entry['route'], $params);
+
+            $strictHeatmapFailure = $entry['route'] === '/day-time-stats'
+                && strpos($result['db_error'], 'ORDER BY clause is not in GROUP BY clause') !== false
+                && strpos($result['db_error'], 'only_full_group_by') !== false;
+            if (FsmtpTest::knownFailure(
+                $strictHeatmapFailure,
+                'heatmap ordering is rejected by ONLY_FULL_GROUP_BY (app/Http/Controllers/DashboardController.php:60-62,79-81).'
+            )) {
+                return;
+            }
+
+            $strictReportFailure = $entry['route'] === 'sending_stats'
+                && strpos($result['db_error'], 'SELECT list is not in GROUP BY clause') !== false
+                && strpos($result['db_error'], 'only_full_group_by') !== false;
+            if (FsmtpTest::knownFailure(
+                $strictReportFailure,
+                'grouped reporting SELECT is rejected by ONLY_FULL_GROUP_BY (app/Services/Reporting.php:40,45,58).'
+            )) {
+                return;
+            }
+
             FsmtpTest::assertAjaxHealthy(
                 $result,
                 $entry['method'] . ' ' . $entry['route'] . ' [' . $variation['label'] . ']'

--- a/tests/bin/run-smoke.php
+++ b/tests/bin/run-smoke.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Phase 1 — read-only admin-AJAX smoke.
+ *
+ * Every GET route is dispatched with every concrete variation represented by
+ * the Vue 2 admin application. POST routes live in the same authoritative
+ * manifest but are exercised by the permission and integration tiers.
+ */
+
+require_once dirname(__DIR__) . '/lib/harness.php';
+
+FsmtpTest::boot();
+
+$manifest = require dirname(__DIR__) . '/smoke/routes.manifest.php';
+$filter = '';
+foreach ((array) $args as $argument) {
+    if (strpos($argument, '--filter=') === 0) {
+        $filter = substr($argument, 9);
+    } elseif (strpos($argument, 'filter=') === 0) {
+        $filter = substr($argument, 7);
+    }
+}
+
+// The docs route intentionally reads a remote public feed. Exercise the
+// controller formatter with a deterministic fixture and block every other
+// outbound request (notification/provider calls included).
+FsmtpTest::interceptHttp(function ($url) {
+    if (strpos($url, 'fluentsmtp.com/wp-json/wp/v2/docs') !== false) {
+        $body = wp_json_encode([
+            [
+                'title' => ['rendered' => 'Test document'],
+                'content' => ['rendered' => '<p>Fixture</p>'],
+                'link' => 'https://example.test/docs/fixture',
+                'taxonomy_info' => [
+                    'doc_category' => [
+                        ['value' => 'testing', 'label' => 'Testing'],
+                    ],
+                ],
+            ],
+        ]);
+
+        return [
+            'headers'  => [],
+            'body'     => $body,
+            'response' => ['code' => 200, 'message' => 'OK'],
+            'cookies'  => [],
+            'filename' => null,
+        ];
+    }
+
+    return null;
+});
+
+/** Resolve manifest tokens without creating or changing site data. */
+$resolveTokens = function () {
+    global $wpdb;
+
+    $logId = $wpdb->get_var(
+        "SELECT id FROM {$wpdb->prefix}fsmpt_email_logs ORDER BY id DESC LIMIT 1"
+    );
+
+    $today = current_time('Y-m-d');
+    return [
+        'today'              => $today,
+        '7_days_ago'         => gmdate('Y-m-d', strtotime($today . ' -7 days')),
+        '30_days_ago'        => gmdate('Y-m-d', strtotime($today . ' -30 days')),
+        '90_days_ago'        => gmdate('Y-m-d', strtotime($today . ' -90 days')),
+        'log_id'             => $logId ? (int) $logId : null,
+        'missing_connection' => 'fsmtp-suite-missing-connection',
+        'search'             => 'fsmtp-suite-no-match',
+    ];
+};
+
+$tokens = $resolveTokens();
+
+/** Recursively replace exact manifest tokens without changing scalar types. */
+$replaceTokens = function ($value) use (&$replaceTokens, $tokens) {
+    if (is_array($value)) {
+        foreach ($value as $key => $item) {
+            $value[$key] = $replaceTokens($item);
+        }
+        return $value;
+    }
+    if (!is_string($value)) {
+        return $value;
+    }
+    foreach ($tokens as $token => $replacement) {
+        if ($value === '{' . $token . '}') {
+            return $replacement;
+        }
+        if ($replacement !== null) {
+            $value = str_replace('{' . $token . '}', (string) $replacement, $value);
+        }
+    }
+    return $value;
+};
+
+$getRoutes = array_values(array_filter($manifest, function ($entry) {
+    return $entry['method'] === 'GET';
+}));
+$caseCount = array_sum(array_map(function ($entry) {
+    return count($entry['cases']);
+}, $getRoutes));
+
+WP_CLI::log(sprintf(
+    "FluentSMTP AJAX smoke — %d GET routes, %d variations%s\n",
+    count($getRoutes),
+    $caseCount,
+    $filter ? ' (filter: ' . $filter . ')' : ''
+));
+
+foreach ($getRoutes as $entry) {
+    foreach ($entry['cases'] as $variation) {
+        $label = $variation['label'];
+        if ($filter !== '' && stripos($entry['route'] . ' ' . $label, $filter) === false) {
+            continue;
+        }
+
+        FsmtpTest::case($entry['method'] . ' ' . $entry['route'] . ' — ' . $label, function () use (
+            $entry,
+            $variation,
+            $replaceTokens,
+            $tokens
+        ) {
+            if (!empty($variation['needs_log']) && !$tokens['log_id']) {
+                FsmtpTest::skip('no email log exists for the read-only viewer route');
+                return;
+            }
+
+            $params = $replaceTokens($variation['params']);
+            $result = FsmtpTest::ajax($entry['method'], $entry['route'], $params);
+            FsmtpTest::assertAjaxHealthy(
+                $result,
+                $entry['method'] . ' ' . $entry['route'] . ' [' . $variation['label'] . ']'
+            );
+        });
+    }
+}
+
+FsmtpTest::finish('AJAX SMOKE');

--- a/tests/browser/README.md
+++ b/tests/browser/README.md
@@ -1,0 +1,21 @@
+# FluentSMTP browser smoke
+
+Build production assets before every run:
+
+```bash
+pnpm run prod
+```
+
+`admin-screen-smoke.mjs` exports the complete eight-route manifest and a runner
+for the repository's browser-control surface. Give it an authenticated tab on a
+local WordPress install, a base URL, and a fail-closed outbound HTTP seam. The
+fixture site needs one non-secret SMTP connection so the connections screen does
+not redirect to the first-run wizard.
+
+The runner requires one visible `.fluent-mail-app` root and two route-specific
+content markers on every screen. An HTTP 200 with an empty Vue root therefore
+fails the phase.
+
+The regular static tier also compares this manifest to
+`resources/admin/routes.js`, so adding or removing a Vue route cannot silently
+leave the browser smoke incomplete.

--- a/tests/browser/README.md
+++ b/tests/browser/README.md
@@ -19,3 +19,34 @@ fails the phase.
 The regular static tier also compares this manifest to
 `resources/admin/routes.js`, so adding or removing a Vue route cannot silently
 leave the browser smoke incomplete.
+
+## Authenticated E2E flows
+
+`admin-e2e.mjs` exports three DOM-grounded flows for a browser-client Tab:
+
+- dashboard `Last week` range selection and report refresh;
+- email-log search with a unique no-match term;
+- test-email submission through FluentSMTP's Simulator provider.
+
+Before opening the admin page, copy
+`fixtures/fsmtp-e2e-safety.php` to the target site's `wp-content/mu-plugins`
+directory. The runner refuses every flow unless the rendered safety marker
+proves that Simulator resolution, the log fuse, the outbound-HTTP fuse, and the
+settings-write fuse are active. Record the real FluentSMTP log count and a hash
+of `fluentmail-settings` before and after the run, then remove the copied
+MU-plugin. If the stored connection list is empty, the fixture supplies a
+non-secret, request-only virtual connection so the configured dashboard and
+email-test branches can run without a database write. The source fixture
+remains in this repository; the installed copy must never be left active after
+testing.
+
+With an authenticated browser-client `tab`, run:
+
+```js
+const { runAdminE2E } = await import('./tests/browser/admin-e2e.mjs');
+const results = await runAdminE2E(tab, 'https://local-wordpress.test');
+```
+
+All three results must have `passed: true`. The browser suite is deliberately
+manual because it reuses the developer's authenticated local admin session;
+the regular local runner never stores or synthesizes login credentials.

--- a/tests/browser/admin-e2e.mjs
+++ b/tests/browser/admin-e2e.mjs
@@ -1,0 +1,192 @@
+/**
+ * Three authenticated browser flows for the FluentSMTP admin application.
+ *
+ * The caller supplies a browser-client Tab. The temporary MU-plugin in
+ * fixtures/fsmtp-e2e-safety.php must be installed before this runner is used.
+ */
+
+const safetyAttributes = [
+    'simulator',
+    'log-fuse',
+    'http-fuse',
+    'settings-fuse',
+];
+
+function invariant(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+async function requireUnique(locator, label) {
+    const count = await locator.count();
+    invariant(count === 1, `${label}: expected one control, found ${count}`);
+    return locator;
+}
+
+async function openAdminRoute(tab, adminUrl, hash, marker) {
+    await tab.goto(adminUrl + hash);
+    await tab.playwright.waitForLoadState({ state: 'domcontentloaded', timeoutMs: 10000 });
+
+    const app = await requireUnique(tab.playwright.locator('.fluent-mail-app'), 'FluentSMTP app');
+    const content = await app.innerText({ timeoutMs: 10000 });
+    invariant(content.includes(marker), `${hash}: missing route marker "${marker}"`);
+}
+
+async function assertSafety(tab, flow) {
+    const state = await tab.playwright.evaluate(() => {
+        const marker = document.querySelector('#fsmtp-e2e-safety');
+        if (!marker) {
+            return null;
+        }
+
+        return {
+            simulator: marker.getAttribute('data-simulator'),
+            'log-fuse': marker.getAttribute('data-log-fuse'),
+            'http-fuse': marker.getAttribute('data-http-fuse'),
+            'settings-fuse': marker.getAttribute('data-settings-fuse'),
+        };
+    });
+
+    invariant(state, `${flow}: E2E safety marker is absent`);
+    for (const attribute of safetyAttributes) {
+        invariant(
+            state[attribute] === 'active',
+            `${flow}: ${attribute} is not active`
+        );
+    }
+}
+
+async function dashboardRangeFlow(tab, adminUrl) {
+    const name = 'dashboard last-week report';
+    await openAdminRoute(tab, adminUrl, '/', 'Sending Stats');
+    await assertSafety(tab, name);
+
+    const start = await requireUnique(
+        tab.playwright.getByRole('textbox', { name: 'Start date' }),
+        `${name} start date`
+    );
+    await start.click();
+
+    const shortcut = await requireUnique(
+        tab.playwright.getByRole('button', { name: 'Last week', exact: true }),
+        `${name} shortcut`
+    );
+    await shortcut.click();
+
+    const range = await tab.playwright.evaluate(() => {
+        const startInput = document.querySelector('.dashboard input[placeholder="Start date"]');
+        const endInput = document.querySelector('.dashboard input[placeholder="End date"]');
+        return {
+            start: startInput ? startInput.value : '',
+            end: endInput ? endInput.value : '',
+        };
+    });
+    invariant(range.start && range.end, `${name}: shortcut did not populate both dates`);
+    invariant(range.start !== range.end, `${name}: shortcut did not create a date range`);
+
+    const apply = await requireUnique(
+        tab.playwright.getByRole('button', { name: 'Apply', exact: true }),
+        `${name} apply`
+    );
+    await apply.click();
+
+    const chart = await requireUnique(
+        tab.playwright.locator('.dashboard .fss_chart_box'),
+        `${name} chart`
+    );
+    await chart.waitFor({ state: 'visible', timeoutMs: 10000 });
+    await assertSafety(tab, name);
+}
+
+async function logsSearchFlow(tab, adminUrl) {
+    const name = 'email logs no-match search';
+    await openAdminRoute(tab, adminUrl, '/logs', 'Email Logs');
+    await assertSafety(tab, name);
+
+    const searchTerm = `fsmtp-e2e-no-match-${Date.now()}`;
+    const search = await requireUnique(
+        tab.playwright.getByRole('textbox', { name: 'Type & press enter...' }),
+        `${name} input`
+    );
+    await search.fill(searchTerm);
+    await search.press('Enter');
+
+    const emptyState = tab.playwright.getByText('No Data', { exact: true });
+    await emptyState.waitFor({ state: 'visible', timeoutMs: 10000 });
+
+    const result = await tab.playwright.evaluate(() => ({
+        hash: window.location.hash,
+        rows: document.querySelectorAll('.logs .el-table__body-wrapper tbody tr').length,
+    }));
+    invariant(result.hash.includes(`search=${searchTerm}`), `${name}: URL did not preserve the search`);
+    invariant(result.rows === 0, `${name}: impossible search returned ${result.rows} rows`);
+    await assertSafety(tab, name);
+}
+
+async function simulatorEmailFlow(tab, adminUrl) {
+    const name = 'simulator-backed test email';
+    await openAdminRoute(tab, adminUrl, '/test', 'Send Test Email');
+    await assertSafety(tab, name);
+
+    const recipient = await requireUnique(
+        tab.playwright.locator('input[name="fluentsmtp_test_to"]'),
+        `${name} recipient`
+    );
+    await recipient.fill('fsmtp-e2e-recipient@example.test');
+
+    const send = await requireUnique(
+        tab.playwright.locator('.test_form button.el-button--primary'),
+        `${name} send`
+    );
+    await assertSafety(tab, `${name} pre-send`);
+    await send.click();
+
+    const success = tab.playwright.locator('.success_wrapper h3');
+    try {
+        await success.waitFor({ state: 'visible', timeoutMs: 10000 });
+    } catch (error) {
+        throw new Error(`${name}: success confirmation did not render`);
+    }
+    invariant(
+        (await success.innerText()).trim() === 'Test Email Has been successfully sent',
+        `${name}: success confirmation did not render`
+    );
+    await assertSafety(tab, name);
+}
+
+export const browserFlows = {
+    dashboard: dashboardRangeFlow,
+    logs: logsSearchFlow,
+    email: simulatorEmailFlow,
+};
+
+export async function runAdminE2E(tab, baseUrl, requestedFlows = Object.keys(browserFlows)) {
+    // The query nonce forces one server navigation even when the caller's tab
+    // is already on this hash-based SPA, so a newly installed safety MU-plugin
+    // cannot be hidden by an in-memory admin document.
+    const adminUrl = baseUrl.replace(/\/$/, '')
+        + `/wp-admin/options-general.php?page=fluent-mail&fsmtp_e2e=${Date.now()}#`;
+    const results = [];
+
+    for (const key of requestedFlows) {
+        const flow = browserFlows[key];
+        if (!flow) {
+            results.push({ name: key, passed: false, error: 'unknown flow' });
+            continue;
+        }
+
+        try {
+            await flow(tab, adminUrl);
+            results.push({ name: key, passed: true });
+        } catch (error) {
+            results.push({
+                name: key,
+                passed: false,
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+
+    return results;
+}

--- a/tests/browser/admin-screen-smoke.mjs
+++ b/tests/browser/admin-screen-smoke.mjs
@@ -1,0 +1,45 @@
+/**
+ * Browser smoke for FluentSMTP's Vue admin routes.
+ *
+ * The caller supplies an authenticated browser-client Tab and must install a
+ * fail-closed outbound HTTP seam. This module deliberately has no Playwright
+ * dependency: it runs through the browser-control surface used by the suite.
+ */
+
+export const adminScreens = [
+    { name: 'dashboard', hash: '/', markers: ['Sending Stats', 'Quick Overview'] },
+    { name: 'connections', hash: '/connections', markers: ['Active Email Connections', 'General Settings'] },
+    { name: 'new connection', hash: '/connection', markers: ['Add Connection', 'Connection Provider'] },
+    { name: 'email test', hash: '/test', markers: ['Send Test Email', 'Send To'] },
+    { name: 'email logs', hash: '/logs', markers: ['Email Logs', 'Filter'] },
+    { name: 'alerts', hash: '/notification-settings', markers: ['Summary Email', 'Email Sending Error Notifications'] },
+    { name: 'about', hash: '/support', markers: ['About', 'Contributors'] },
+    { name: 'documentation', hash: '/documentation', markers: ['How can we help you?', 'Please view the documentation first.'] },
+];
+
+export async function runAdminScreenSmoke(tab, baseUrl) {
+    const results = [];
+    const adminUrl = baseUrl.replace(/\/$/, '') + '/wp-admin/options-general.php?page=fluent-mail#';
+
+    for (const screen of adminScreens) {
+        await tab.goto(adminUrl + screen.hash);
+        await tab.playwright.waitForLoadState({ state: 'domcontentloaded', timeoutMs: 10000 });
+
+        const app = tab.playwright.locator('.fluent-mail-app');
+        const appCount = await app.count();
+        const visible = appCount === 1 && await app.isVisible();
+        const content = visible ? await app.innerText({ timeoutMs: 5000 }) : '';
+        const missing = screen.markers.filter((marker) => !content.includes(marker));
+
+        results.push({
+            name: screen.name,
+            hash: screen.hash,
+            passed: appCount === 1 && visible && missing.length === 0,
+            appCount,
+            visible,
+            missing,
+        });
+    }
+
+    return results;
+}

--- a/tests/browser/fixtures/fsmtp-e2e-safety.php
+++ b/tests/browser/fixtures/fsmtp-e2e-safety.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Temporary MU-plugin for the authenticated FluentSMTP browser flows.
+ *
+ * Copy this exact file to wp-content/mu-plugins only for the browser run and
+ * remove it afterwards. It closes every transport before FluentSMTP loads,
+ * disables logging, and prevents the E2E flows from changing real settings.
+ */
+
+if (!defined('FLUENTMAIL_SIMULATE_EMAILS')) {
+    define('FLUENTMAIL_SIMULATE_EMAILS', true);
+}
+
+if (!defined('FLUENTMAIL_LOG_OFF')) {
+    define('FLUENTMAIL_LOG_OFF', true);
+}
+
+add_filter('fluentmail_will_log_email', '__return_false', PHP_INT_MAX);
+
+add_filter('pre_http_request', function ($preempt, $args, $url) {
+    return new WP_Error(
+        'fsmtp_e2e_http_blocked',
+        'FluentSMTP E2E safety fixture blocked outbound HTTP.'
+    );
+}, PHP_INT_MAX, 3);
+
+add_filter('pre_update_option_fluentmail-settings', function ($newValue, $oldValue) {
+    return $oldValue;
+}, PHP_INT_MAX, 2);
+
+// A blank fixture site still needs the configured-app branch for the dashboard
+// and test-email flows. Supply a request-only, non-secret connection without
+// changing the stored option; Simulator resolves before this SMTP data is used.
+$fsmtpE2eVirtualSettings = function ($settings) {
+    if (!empty($settings['connections'])) {
+        return $settings;
+    }
+
+    $settings = is_array($settings) ? $settings : [];
+    $connectionKey = 'fsmtp_e2e_virtual';
+    $sender = 'fsmtp-e2e-sender@example.test';
+
+    $settings['connections'] = [
+        $connectionKey => [
+            'title'             => 'FluentSMTP E2E Simulator',
+            'provider_settings' => [
+                'provider'         => 'smtp',
+                'sender_email'     => $sender,
+                'sender_name'      => 'FluentSMTP E2E',
+                'host'             => 'smtp.example.test',
+                'port'             => 2525,
+                'auth'             => 'no',
+                'encryption'       => 'none',
+                'force_from_name'  => 'no',
+                'force_from_email' => 'no',
+            ],
+        ],
+    ];
+    $settings['mappings'] = [$sender => $connectionKey];
+    $settings['misc'] = array_merge([
+        'log_emails'              => 'no',
+        'log_saved_interval_days' => '14',
+        'disable_fluentcrm_logs'  => 'no',
+        'default_connection'      => $connectionKey,
+    ], isset($settings['misc']) && is_array($settings['misc']) ? $settings['misc'] : []);
+    $settings['misc']['default_connection'] = $connectionKey;
+
+    return $settings;
+};
+
+add_filter('option_fluentmail-settings', $fsmtpE2eVirtualSettings, PHP_INT_MAX);
+add_filter('default_option_fluentmail-settings', $fsmtpE2eVirtualSettings, PHP_INT_MAX);
+
+// The E2E runner adds a per-run query nonce. Carry it onto FluentSMTP assets
+// so proof-of-catch rebuilds cannot be hidden by the browser cache.
+$fsmtpE2eAssetNonce = isset($_GET['fsmtp_e2e'])
+    ? sanitize_key(wp_unslash($_GET['fsmtp_e2e']))
+    : '';
+
+$fsmtpE2eBustAsset = function ($src) use ($fsmtpE2eAssetNonce) {
+    if ($fsmtpE2eAssetNonce && strpos($src, '/fluent-smtp/') !== false) {
+        return add_query_arg('fsmtp_e2e_asset', $fsmtpE2eAssetNonce, $src);
+    }
+
+    return $src;
+};
+
+add_filter('script_loader_src', $fsmtpE2eBustAsset, PHP_INT_MAX);
+add_filter('style_loader_src', $fsmtpE2eBustAsset, PHP_INT_MAX);
+
+add_action('admin_footer', function () {
+    $simulatorActive = false;
+
+    if (function_exists('fluentMailGetProvider')) {
+        $provider = fluentMailGetProvider('fsmtp-e2e-safety@example.test', true);
+        $simulatorActive = $provider instanceof \FluentMail\App\Services\Mailer\Providers\Simulator\Handler;
+    }
+
+    printf(
+        '<div id="fsmtp-e2e-safety" data-simulator="%1$s" data-log-fuse="%2$s" data-http-fuse="%3$s" data-settings-fuse="%4$s" hidden></div>',
+        $simulatorActive ? 'active' : 'inactive',
+        defined('FLUENTMAIL_LOG_OFF') && FLUENTMAIL_LOG_OFF ? 'active' : 'inactive',
+        has_filter('pre_http_request') ? 'active' : 'inactive',
+        has_filter('pre_update_option_fluentmail-settings') ? 'active' : 'inactive'
+    );
+}, PHP_INT_MAX);

--- a/tests/coverage/zero-coverage-triage.php
+++ b/tests/coverage/zero-coverage-triage.php
@@ -1,0 +1,75 @@
+<?php
+/** Phase 13 decisions for production PHP files over 100 lines with zero hits. */
+
+$triage = [];
+
+$providerHandlers = [
+    'app/Services/Mailer/Providers/AmazonSes/Handler.php' => 'Amazon SES',
+    'app/Services/Mailer/Providers/Cloudflare/Handler.php' => 'Cloudflare',
+    'app/Services/Mailer/Providers/ElasticMail/Handler.php' => 'Elastic Email',
+    'app/Services/Mailer/Providers/Mailgun/Handler.php' => 'Mailgun',
+    'app/Services/Mailer/Providers/PepiPost/Handler.php' => 'PepiPost',
+    'app/Services/Mailer/Providers/Postmark/Handler.php' => 'Postmark',
+    'app/Services/Mailer/Providers/SendGrid/Handler.php' => 'SendGrid',
+    'app/Services/Mailer/Providers/SendInBlue/Handler.php' => 'Brevo/SendInBlue',
+    'app/Services/Mailer/Providers/Smtp2Go/Handler.php' => 'SMTP2GO',
+    'app/Services/Mailer/Providers/SparkPost/Handler.php' => 'SparkPost',
+    'app/Services/Mailer/Providers/TransMail/Handler.php' => 'TransMail',
+];
+
+foreach ($providerHandlers as $path => $provider) {
+    $triage[$path] = [
+        'category' => 'outbound provider adapter',
+        'reason'   => "Every send-path test forces Simulator, so the live {$provider} transport is intentionally never resolved or called.",
+        'next'     => "Add a {$provider} contract fixture with fail-closed HTTP/SDK seams; assert request mapping and error normalization without network.",
+    ];
+}
+
+$triage['app/Services/Mailer/Providers/AmazonSes/SimpleEmailService.php'] = [
+    'category' => 'Amazon SES protocol client',
+    'reason'   => 'The low-level SES HTTP and signing client is bypassed while Simulator is mandatory.',
+    'next'     => 'Add deterministic AWS signature/request fixtures with a fixed clock and a fail-closed HTTP responder.',
+];
+$triage['app/Services/Mailer/Providers/AmazonSes/SimpleEmailServiceMessage.php'] = [
+    'category' => 'Amazon SES message serializer',
+    'reason'   => 'No current safe-send case constructs the provider-specific SES MIME/message object.',
+    'next'     => 'Add pure recipient, header, attachment, and MIME serialization fixtures without dispatching a request.',
+];
+$triage['app/Services/Mailer/Providers/AmazonSes/SimpleEmailServiceRequest.php'] = [
+    'category' => 'Amazon SES request serializer',
+    'reason'   => 'Canonical SES request construction is below the Simulator seam and receives no runtime hit.',
+    'next'     => 'Add fixed-input canonical query and signature fixtures before enabling the SES handler contract test.',
+];
+
+$triage['app/Services/TransStrings.php'] = [
+    'category' => 'browser-only localization catalog',
+    'reason'   => 'The Vue browser smoke loads localized admin assets in a web process, outside the merged WP-CLI PCOV runs.',
+    'next'     => 'Capture web-process PHP coverage or add a catalog contract when translated-key drift becomes a target.',
+];
+$triage['app/views/admin/digest_email.php'] = [
+    'category' => 'notification rendering',
+    'reason'   => 'Notification settings and scheduling are covered, but the digest template itself is not rendered.',
+    'next'     => 'Add a deterministic digest render fixture that asserts escaped visible content without sending email.',
+];
+$triage['includes/Request/File.php'] = [
+    'category' => 'file-upload infrastructure',
+    'reason'   => 'No current happy-path route fixture submits an uploaded attachment, so the file wrapper remains dormant.',
+    'next'     => 'Cover attachment normalization in the Simulator-backed end-to-end send flow, using an exact temporary file fixture.',
+];
+$triage['includes/Support/Collection.php'] = [
+    'category' => 'bundled framework utility',
+    'reason'   => 'The plugin paths exercised in Round 2 do not call this generic collection implementation.',
+    'next'     => 'Add callsite-driven tests only when production code adopts Collection; avoid blanket testing unused framework surface.',
+];
+$triage['includes/Support/Str.php'] = [
+    'category' => 'bundled framework utility',
+    'reason'   => 'The plugin paths exercised in Round 2 do not call this large generic string helper.',
+    'next'     => 'Add callsite-driven tests for the specific helpers when a production feature depends on them.',
+];
+$triage['includes/View/View.php'] = [
+    'category' => 'web-process view renderer',
+    'reason'   => 'Admin rendering occurs in the Phase 11 browser process, which is outside the WP-CLI PCOV merger.',
+    'next'     => 'Capture web-process PHP coverage or add an isolated template-render contract alongside digest rendering.',
+];
+
+return $triage;

--- a/tests/integration/cli-behavior.php
+++ b/tests/integration/cli-behavior.php
@@ -1,0 +1,118 @@
+<?php
+
+return function () {
+    global $wpdb;
+
+    $baseSettings = [
+        'connections' => [],
+        'mappings'    => [],
+        'misc'        => [
+            'simulate_emails'        => 'yes',
+            'log_emails'             => 'no',
+            'log_saved_interval_days'=> '14',
+            'default_connection'     => '',
+        ],
+    ];
+    $environmentFor = function (array $settings) {
+        return [
+            'FSMTP_SUITE_SETTINGS_B64' => base64_encode(wp_json_encode($settings)),
+        ];
+    };
+    $readHealthOption = function () use ($wpdb) {
+        return $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+                \FluentMail\App\Services\ConnectionHealth::OPTION_KEY
+            )
+        );
+    };
+
+    FsmtpTest::case('wp fluent-smtp test sends only through Simulator', function () use (
+        $baseSettings,
+        $environmentFor
+    ) {
+        $before = FsmtpTest::protectedTableCounts();
+        $recipient = 'fsmtp-cli-' . FsmtpTest::uniq() . '@example.test';
+        $result = FsmtpTest::wpCli(
+            ['fluent-smtp', 'test', '--to=' . $recipient, '--text'],
+            $environmentFor($baseSettings)
+        );
+
+        FsmtpTest::assertSame(0, $result['code'], 'test command exit code');
+        FsmtpTest::assert(
+            strpos($result['output'], 'FluentSMTP CLI safety: Simulator active.') !== false,
+            'child process did not prove Simulator resolution'
+        );
+        FsmtpTest::assert(
+            strpos($result['output'], 'Test email handed to the provider for ' . $recipient) !== false,
+            'test command success output'
+        );
+        FsmtpTest::assertSame($before, FsmtpTest::protectedTableCounts(), 'test command log count');
+    });
+
+    FsmtpTest::case('wp fluent-smtp health exits non-zero for a broken connection', function () use (
+        $baseSettings,
+        $environmentFor,
+        $readHealthOption
+    ) {
+        $sender = 'fsmtp-broken-' . FsmtpTest::uniq() . '@example.test';
+        $settings = $baseSettings;
+        $settings['connections']['suite-broken'] = [
+            'title' => 'Suite Broken SMTP',
+            'provider_settings' => [
+                'provider'     => 'smtp',
+                'sender_email' => $sender,
+                'auth'         => 'no',
+            ],
+        ];
+        $settings['mappings'][$sender] = 'suite-broken';
+        $settings['misc']['default_connection'] = 'suite-broken';
+        $before = $readHealthOption();
+
+        $result = FsmtpTest::wpCli(
+            ['fluent-smtp', 'health', '--format=json'],
+            $environmentFor($settings)
+        );
+
+        FsmtpTest::assertSame(1, $result['code'], 'broken health command exit code');
+        FsmtpTest::assert(strpos($result['output'], $sender) !== false, 'health output sender');
+        FsmtpTest::assert(strpos($result['output'], 'SMTP host is required') !== false, 'health output provider error');
+        FsmtpTest::assert(
+            strpos($result['output'], '1 of 1 connection(s) need attention') !== false,
+            'health output failure count'
+        );
+        FsmtpTest::assertSame($before, $readHealthOption(), 'health report option write fuse');
+    });
+
+    FsmtpTest::case('wp fluent-smtp stats reports both status metrics', function () use (
+        $baseSettings,
+        $environmentFor
+    ) {
+        $result = FsmtpTest::wpCli(
+            ['fluent-smtp', 'stats', '--format=json'],
+            $environmentFor($baseSettings)
+        );
+
+        FsmtpTest::assertSame(0, $result['code'], 'stats command exit code');
+        FsmtpTest::assert(strpos($result['stdout'], '"metric":"sent"') !== false, 'stats sent metric');
+        FsmtpTest::assert(strpos($result['stdout'], '"metric":"failed"') !== false, 'stats failed metric');
+    });
+
+    FsmtpTest::case('wp fluent-smtp prune-logs safely handles no matches', function () use (
+        $baseSettings,
+        $environmentFor
+    ) {
+        // MySQL TIMESTAMP values cannot predate 1970. A roughly 821-year
+        // retention window therefore guarantees that this real-table command
+        // cannot match any valid FluentSMTP row on the current date.
+        $before = FsmtpTest::protectedTableCounts();
+        $result = FsmtpTest::wpCli(
+            ['fluent-smtp', 'prune-logs', '--days=300000', '--yes'],
+            $environmentFor($baseSettings)
+        );
+
+        FsmtpTest::assertSame(0, $result['code'], 'prune command exit code');
+        FsmtpTest::assert(strpos($result['output'], 'Deleted 0 log entries.') !== false, 'prune no-match output');
+        FsmtpTest::assertSame($before, FsmtpTest::protectedTableCounts(), 'prune command log count');
+    });
+};

--- a/tests/integration/cli-behavior.php
+++ b/tests/integration/cli-behavior.php
@@ -98,21 +98,22 @@ return function () {
         FsmtpTest::assert(strpos($result['stdout'], '"metric":"failed"') !== false, 'stats failed metric');
     });
 
-    FsmtpTest::case('wp fluent-smtp prune-logs safely handles no matches', function () use (
+    FsmtpTest::case('wp fluent-smtp prune-logs fuses production log deletes in the child process', function () use (
         $baseSettings,
         $environmentFor
     ) {
-        // MySQL TIMESTAMP values cannot predate 1970. A roughly 821-year
-        // retention window therefore guarantees that this real-table command
-        // cannot match any valid FluentSMTP row on the current date.
         $before = FsmtpTest::protectedTableCounts();
         $result = FsmtpTest::wpCli(
-            ['fluent-smtp', 'prune-logs', '--days=300000', '--yes'],
+            ['fluent-smtp', 'prune-logs', '--days=1', '--yes'],
             $environmentFor($baseSettings)
         );
 
         FsmtpTest::assertSame(0, $result['code'], 'prune command exit code');
-        FsmtpTest::assert(strpos($result['output'], 'Deleted 0 log entries.') !== false, 'prune no-match output');
+        FsmtpTest::assert(
+            strpos($result['output'], 'FluentSMTP CLI safety: production log DELETE fused.') !== false,
+            'child process did not prove the production-log write fuse'
+        );
+        FsmtpTest::assert(strpos($result['output'], 'Deleted 0 log entries.') !== false, 'fused prune output');
         FsmtpTest::assertSame($before, FsmtpTest::protectedTableCounts(), 'prune command log count');
     });
 };

--- a/tests/integration/connection-behavior.php
+++ b/tests/integration/connection-behavior.php
@@ -1,0 +1,269 @@
+<?php
+
+use FluentMail\App\Hooks\Handlers\SchedulerHandler;
+use FluentMail\App\Models\Settings;
+use FluentMail\App\Services\ConnectionHealth;
+use FluentMail\App\Services\Mailer\Providers\Factory;
+use FluentMail\App\Services\Mailer\Providers\Gmail\Handler as GmailHandler;
+
+/** Outbound Google client seam: no Guzzle request can leave the process. */
+class FsmtpSuiteGoogleClient
+{
+    public static $tokens = [];
+
+    public function setClientId($value) {}
+    public function setClientSecret($value) {}
+    public function addScope($value) {}
+    public function setAccessType($value) {}
+    public function setApprovalPrompt($value) {}
+    public function setAccessToken($value) {}
+    public function refreshToken($value) { return self::$tokens; }
+}
+
+if (!class_exists('FluentSmtpLib\\Google\\Client', false)) {
+    class_alias(FsmtpSuiteGoogleClient::class, 'FluentSmtpLib\\Google\\Client');
+}
+
+class FsmtpSuiteUnmappedSettings extends Settings
+{
+    public function getConnection($email)
+    {
+        return [];
+    }
+}
+
+class FsmtpSuiteFactoryWithDefault extends Factory
+{
+    public function getDefaultProvider()
+    {
+        return [
+            'provider'        => 'smtp',
+            'sender_email'    => 'default@example.test',
+            'sender_name'     => 'Suite Default',
+            'host'            => 'smtp.example.test',
+            'port'            => 2525,
+            'auth'            => 'no',
+            'encryption'      => 'none',
+            'force_from_name' => 'no',
+            'force_from_email'=> 'no',
+        ];
+    }
+}
+
+return function () {
+    $outlookSettings = function ($sender) {
+        return [
+            'provider'      => 'outlook',
+            'sender_email'  => $sender,
+            'key_store'     => 'db',
+            'client_id'     => 'suite-client',
+            'client_secret' => 'suite-secret',
+            'access_token'  => 'expired-access-token',
+            'refresh_token' => 'suite-refresh-token',
+            'expire_stamp'  => time() - 60,
+        ];
+    };
+
+    $gmailSettings = function ($sender) {
+        return [
+            'provider'      => 'gmail',
+            'sender_email'  => $sender,
+            'key_store'     => 'db',
+            'client_id'     => 'suite-client',
+            'client_secret' => 'suite-secret',
+            'access_token'  => 'expired-access-token',
+            'refresh_token' => 'suite-refresh-token',
+            'expire_stamp'  => time() - 60,
+        ];
+    };
+
+    /** Run successful renewals without persisting settings or cron events. */
+    $withWriteFuses = function (callable $callback) {
+        global $wpdb;
+
+        $before = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+                'fluentmail-settings'
+            )
+        );
+        $optionFuse = function ($newValue, $oldValue) {
+            return $oldValue;
+        };
+        $scheduleFuse = function () {
+            return false;
+        };
+
+        add_filter('pre_update_option_fluentmail-settings', $optionFuse, PHP_INT_MAX, 2);
+        add_filter('pre_schedule_event', $scheduleFuse, PHP_INT_MAX, 3);
+        try {
+            return $callback();
+        } finally {
+            remove_filter('pre_update_option_fluentmail-settings', $optionFuse, PHP_INT_MAX);
+            remove_filter('pre_schedule_event', $scheduleFuse, PHP_INT_MAX);
+            wp_cache_delete('fluentmail-settings', 'options');
+            wp_cache_delete('alloptions', 'options');
+
+            $after = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+                    'fluentmail-settings'
+                )
+            );
+            FsmtpTest::assertSame($before, $after, 'OAuth write fuse preserved FluentSMTP settings');
+        }
+    };
+
+    FsmtpTest::case('unmapped sender falls back to the default provider settings shape', function () {
+        $factory = new FsmtpSuiteFactoryWithDefault(
+            fluentMail(),
+            new FsmtpSuiteUnmappedSettings()
+        );
+
+        $handler = $factory->get('unmapped@example.test');
+
+        FsmtpTest::assert(
+            $handler instanceof \FluentMail\App\Services\Mailer\Providers\Smtp\Handler,
+            'unmapped sender did not resolve the default SMTP handler'
+        );
+        FsmtpTest::assertSame(
+            'default@example.test',
+            $handler->getSetting('sender_email'),
+            'default provider settings were applied as-is'
+        );
+    });
+
+    FsmtpTest::case('generic provider health is healthy for valid credentials', function () {
+        $result = (new ConnectionHealth())->checkConnection([
+            'provider' => 'smtp',
+            'host'     => 'smtp.example.test',
+            'port'     => 2525,
+            'auth'     => 'no',
+        ]);
+
+        FsmtpTest::assertSame(ConnectionHealth::STATUS_HEALTHY, $result['status'], 'generic health status');
+        FsmtpTest::assertSame('', $result['message'], 'generic healthy message');
+    });
+
+    FsmtpTest::case('generic provider health flattens validation errors', function () {
+        $result = (new ConnectionHealth())->checkConnection([
+            'provider' => 'smtp',
+            'auth'     => 'no',
+        ]);
+
+        FsmtpTest::assertSame(ConnectionHealth::STATUS_ERROR, $result['status'], 'generic error status');
+        FsmtpTest::assert(strpos($result['message'], 'SMTP host is required') !== false, 'host error was not surfaced');
+        FsmtpTest::assert(strpos($result['message'], 'SMTP port is required') !== false, 'port error was not surfaced');
+    });
+
+    FsmtpTest::case('Outlook rejected grant reaches connection health with provider detail', function () use ($outlookSettings) {
+        $description = 'Suite IdP says the Microsoft refresh grant was revoked.';
+        FsmtpTest::interceptHttp(function ($url) use ($description) {
+            if (strpos($url, 'login.microsoftonline.com/common/oauth2/v2.0/token') !== false) {
+                return [
+                    'headers' => [],
+                    'body' => wp_json_encode([
+                        'error' => 'invalid_grant',
+                        'error_description' => $description,
+                    ]),
+                    'response' => ['code' => 400, 'message' => 'Bad Request'],
+                    'cookies' => [],
+                    'filename' => null,
+                ];
+            }
+            return null;
+        });
+
+        $result = (new ConnectionHealth())->checkConnection(
+            $outlookSettings('outlook-error-' . FsmtpTest::uniq() . '@example.test')
+        );
+
+        FsmtpTest::assertSame(ConnectionHealth::STATUS_ERROR, $result['status'], 'Outlook error status');
+        FsmtpTest::assert(strpos($result['message'], $description) !== false, 'Microsoft error_description did not reach caller');
+        FsmtpTest::assert(strpos($result['message'], 'reconnect') !== false, 'Outlook recovery guidance did not reach caller');
+        FsmtpTest::assertSame(1, count(FsmtpTest::httpRequests()), 'Outlook made one intercepted token request');
+    });
+
+    FsmtpTest::case('Outlook successful token grant reports healthy without persisting', function () use (
+        $outlookSettings,
+        $withWriteFuses
+    ) {
+        FsmtpTest::interceptHttp(function ($url) {
+            if (strpos($url, 'login.microsoftonline.com/common/oauth2/v2.0/token') !== false) {
+                return [
+                    'headers' => [],
+                    'body' => wp_json_encode([
+                        'access_token' => 'suite-new-access',
+                        'expires_in' => 3600,
+                    ]),
+                    'response' => ['code' => 200, 'message' => 'OK'],
+                    'cookies' => [],
+                    'filename' => null,
+                ];
+            }
+            return null;
+        });
+
+        $result = $withWriteFuses(function () use ($outlookSettings) {
+            return (new ConnectionHealth())->checkConnection(
+                $outlookSettings('outlook-healthy-' . FsmtpTest::uniq() . '@example.test')
+            );
+        });
+
+        FsmtpTest::assertSame(ConnectionHealth::STATUS_HEALTHY, $result['status'], 'Outlook healthy status');
+        FsmtpTest::assertSame('', $result['message'], 'Outlook healthy message');
+    });
+
+    FsmtpTest::case('Gmail handler surfaces a rejected grant description', function () use ($gmailSettings) {
+        $description = 'Suite Google grant is expired or revoked.';
+        FsmtpSuiteGoogleClient::$tokens = [
+            'error' => 'invalid_grant',
+            'error_description' => $description,
+        ];
+
+        $method = new ReflectionMethod(GmailHandler::class, 'getApiClient');
+        $method->setAccessible(true);
+        $result = $method->invoke(
+            new GmailHandler(),
+            $gmailSettings('gmail-handler-' . FsmtpTest::uniq() . '@example.test')
+        );
+
+        FsmtpTest::assert(is_wp_error($result), 'Gmail handler did not return WP_Error for rejected grant');
+        FsmtpTest::assertSame($description, $result->get_error_message(), 'Gmail handler error_description');
+    });
+
+    FsmtpTest::case('Gmail rejected grant reaches connection health with provider detail', function () use ($gmailSettings) {
+        $description = 'Suite Google health grant was revoked.';
+        FsmtpSuiteGoogleClient::$tokens = [
+            'error' => 'invalid_grant',
+            'error_description' => $description,
+        ];
+
+        $result = (new ConnectionHealth())->checkConnection(
+            $gmailSettings('gmail-error-' . FsmtpTest::uniq() . '@example.test')
+        );
+
+        FsmtpTest::assertSame(ConnectionHealth::STATUS_ERROR, $result['status'], 'Gmail error status');
+        FsmtpTest::assertSame($description, $result['message'], 'Gmail health error_description');
+    });
+
+    FsmtpTest::case('Gmail successful token grant reports healthy without persisting', function () use (
+        $gmailSettings,
+        $withWriteFuses
+    ) {
+        FsmtpSuiteGoogleClient::$tokens = [
+            'access_token'  => 'suite-new-access',
+            'refresh_token' => 'suite-new-refresh',
+            'expires_in'    => 3600,
+        ];
+
+        $result = $withWriteFuses(function () use ($gmailSettings) {
+            return (new ConnectionHealth())->checkConnection(
+                $gmailSettings('gmail-healthy-' . FsmtpTest::uniq() . '@example.test')
+            );
+        });
+
+        FsmtpTest::assertSame(ConnectionHealth::STATUS_HEALTHY, $result['status'], 'Gmail healthy status');
+        FsmtpTest::assertSame('', $result['message'], 'Gmail healthy message');
+    });
+};

--- a/tests/integration/connection-behavior.php
+++ b/tests/integration/connection-behavior.php
@@ -5,6 +5,7 @@ use FluentMail\App\Models\Settings;
 use FluentMail\App\Services\ConnectionHealth;
 use FluentMail\App\Services\Mailer\Providers\Factory;
 use FluentMail\App\Services\Mailer\Providers\Gmail\Handler as GmailHandler;
+use FluentMail\App\Services\Mailer\Providers\Outlook\Handler as OutlookHandler;
 
 /** Outbound Google client seam: no Guzzle request can leave the process. */
 class FsmtpSuiteGoogleClient
@@ -212,6 +213,50 @@ return function () {
 
         FsmtpTest::assertSame(ConnectionHealth::STATUS_HEALTHY, $result['status'], 'Outlook healthy status');
         FsmtpTest::assertSame('', $result['message'], 'Outlook healthy message');
+    });
+
+    FsmtpTest::case('Outlook refreshes only an expired cached token when force is false', function () use (
+        $outlookSettings,
+        $withWriteFuses
+    ) {
+        FsmtpTest::interceptHttp(function ($url) {
+            if (strpos($url, 'login.microsoftonline.com/common/oauth2/v2.0/token') !== false) {
+                return [
+                    'headers' => [],
+                    'body' => wp_json_encode([
+                        'access_token' => 'suite-refreshed-access',
+                        'expires_in' => 3600,
+                    ]),
+                    'response' => ['code' => 200, 'message' => 'OK'],
+                    'cookies' => [],
+                    'filename' => null,
+                ];
+            }
+            return null;
+        });
+
+        $method = new ReflectionMethod(OutlookHandler::class, 'getAccessToken');
+        $method->setAccessible(true);
+        $handler = new OutlookHandler();
+        $future = array_merge(
+            $outlookSettings('outlook-future-' . FsmtpTest::uniq() . '@example.test'),
+            ['access_token' => 'suite-cached-access', 'expire_stamp' => time() + 600]
+        );
+
+        $cachedToken = $method->invoke($handler, $future, false);
+        FsmtpTest::assertSame('suite-cached-access', $cachedToken, 'future Outlook access token');
+        FsmtpTest::assertSame(0, count(FsmtpTest::httpRequests()), 'future Outlook token request count');
+
+        $expired = array_merge($future, [
+            'sender_email' => 'outlook-expired-' . FsmtpTest::uniq() . '@example.test',
+            'expire_stamp' => time() - 1,
+        ]);
+        $refreshedToken = $withWriteFuses(function () use ($method, $handler, $expired) {
+            return $method->invoke($handler, $expired, false);
+        });
+
+        FsmtpTest::assertSame('suite-refreshed-access', $refreshedToken, 'expired Outlook access token');
+        FsmtpTest::assertSame(1, count(FsmtpTest::httpRequests()), 'expired Outlook token request count');
     });
 
     FsmtpTest::case('Gmail handler surfaces a rejected grant description', function () use ($gmailSettings) {

--- a/tests/integration/coverage-gaps.php
+++ b/tests/integration/coverage-gaps.php
@@ -1,0 +1,90 @@
+<?php
+
+use FluentMail\App\Services\Converter;
+use FluentMail\App\Services\Html2Text;
+
+return function () {
+    FsmtpTest::case('WP Mail SMTP import preserves a complete SMTP connection mapping', function () {
+        global $wpdb;
+
+        $optionName = 'wp_mail_smtp';
+        $fingerprint = function () use ($wpdb, $optionName) {
+            $row = $wpdb->get_row(
+                $wpdb->prepare(
+                    "SELECT option_value, autoload FROM {$wpdb->options} WHERE option_name = %s",
+                    $optionName
+                ),
+                ARRAY_A
+            );
+            return $row ? hash('sha256', $row['option_value'] . '|' . $row['autoload']) : null;
+        };
+        $before = $fingerprint();
+        $fixture = [
+            'mail' => [
+                'from_name'        => 'Coverage Sender',
+                'from_email'       => 'coverage-sender@example.test',
+                'from_name_force'  => 1,
+                'from_email_force' => 1,
+                'return_path'      => 1,
+                'mailer'           => 'smtp',
+            ],
+            'smtp' => [
+                'host'       => 'smtp.example.test',
+                'port'       => 2525,
+                'auth'       => 0,
+                'user'       => 'coverage-user',
+                'pass'       => '',
+                'auto_tls'   => 1,
+                'encryption' => 'tls',
+            ],
+        ];
+
+        $wpdb->query('START TRANSACTION');
+        try {
+            update_option($optionName, $fixture, false);
+            wp_cache_delete($optionName, 'options');
+            wp_cache_delete('alloptions', 'options');
+
+            $suggestion = (new Converter())->getSuggestedConnection();
+            $settings = isset($suggestion['settings']) ? $suggestion['settings'] : [];
+
+            FsmtpTest::assertSame('smtp', isset($settings['provider']) ? $settings['provider'] : null, 'imported provider');
+            FsmtpTest::assertSame('Coverage Sender', isset($settings['sender_name']) ? $settings['sender_name'] : null, 'imported sender name');
+            FsmtpTest::assertSame('coverage-sender@example.test', isset($settings['sender_email']) ? $settings['sender_email'] : null, 'imported sender email');
+            FsmtpTest::assertSame('yes', isset($settings['force_from_name']) ? $settings['force_from_name'] : null, 'imported force-from name');
+            FsmtpTest::assertSame('yes', isset($settings['force_from_email']) ? $settings['force_from_email'] : null, 'imported force-from email');
+            FsmtpTest::assertSame('yes', isset($settings['return_path']) ? $settings['return_path'] : null, 'imported return path');
+            FsmtpTest::assertSame('smtp.example.test', isset($settings['host']) ? $settings['host'] : null, 'imported host');
+            FsmtpTest::assertSame(2525, isset($settings['port']) ? $settings['port'] : null, 'imported port');
+            FsmtpTest::assertSame('no', isset($settings['auth']) ? $settings['auth'] : null, 'imported auth mode');
+            FsmtpTest::assertSame('coverage-user', isset($settings['username']) ? $settings['username'] : null, 'imported username');
+            FsmtpTest::assertSame('', isset($settings['password']) ? $settings['password'] : null, 'imported empty password');
+            FsmtpTest::assertSame('yes', isset($settings['auto_tls']) ? $settings['auto_tls'] : null, 'imported automatic TLS');
+            FsmtpTest::assertSame('tls', isset($settings['encryption']) ? $settings['encryption'] : null, 'imported encryption');
+            FsmtpTest::assertSame('db', isset($settings['key_store']) ? $settings['key_store'] : null, 'imported key store');
+        } finally {
+            $wpdb->query('ROLLBACK');
+            wp_cache_delete($optionName, 'options');
+            wp_cache_delete('alloptions', 'options');
+            wp_cache_delete('notoptions', 'options');
+            FsmtpTest::assertSame($before, $fingerprint(), 'WP Mail SMTP option restoration');
+        }
+    });
+
+    FsmtpTest::case('HTML-to-text conversion preserves readable structure and removes active markup', function () {
+        $html = '<h1>Delivery <strong>Report</strong></h1>'
+            . '<p>Hello &amp; welcome.</p>'
+            . '<ul><li>First</li><li>Second</li></ul>'
+            . '<p><a href="https://example.test/docs">Docs</a></p>'
+            . '<script>suite-script-content</script>';
+        $text = (new Html2Text($html))->getText();
+
+        FsmtpTest::assert(strpos($text, 'DELIVERY REPORT') !== false, 'plain text heading was lost');
+        FsmtpTest::assert(strpos($text, 'Hello & welcome.') !== false, 'plain text entity decoding failed');
+        FsmtpTest::assert(strpos($text, "\t* First") !== false, 'plain text first list item was lost');
+        FsmtpTest::assert(strpos($text, "\t* Second") !== false, 'plain text second list item was lost');
+        FsmtpTest::assert(strpos($text, 'Docs [https://example.test/docs]') !== false, 'plain text link target was lost');
+        FsmtpTest::assert(strpos($text, 'suite-script-content') === false, 'script content leaked into plain text');
+        FsmtpTest::assert(strpos($text, '<') === false, 'HTML markup remained in plain text');
+    });
+};

--- a/tests/integration/database-behavior.php
+++ b/tests/integration/database-behavior.php
@@ -81,6 +81,46 @@ return function () {
         }
     });
 
+    FsmtpTest::case('failed replacement index creation preserves the legacy status index', function () {
+        global $wpdb;
+        $table = FsmtpFactory::emailLogTable(true, false);
+        $addAttempts = 0;
+        $dropAttempts = 0;
+        $ddlFailure = function ($query) use ($table, &$addAttempts, &$dropAttempts) {
+            if (stripos($query, 'ALTER TABLE') === false || strpos($query, $table) === false) {
+                return $query;
+            }
+
+            if (stripos($query, 'ADD INDEX `created_at_status`') !== false) {
+                $addAttempts++;
+                return "ALTER TABLE `{$table}` ADD INDEX `created_at_status` (`fsmtp_missing_column`)";
+            }
+
+            if (stripos($query, 'DROP INDEX `status`') !== false) {
+                $dropAttempts++;
+            }
+            return $query;
+        };
+
+        $wasSuppressing = $wpdb->suppress_errors();
+        add_filter('query', $ddlFailure, PHP_INT_MAX);
+        try {
+            $method = new ReflectionMethod(EmailLogs::class, 'maybeUpgradeIndexes');
+            $method->setAccessible(true);
+            $method->invoke(null, $table);
+            $indexes = FsmtpFactory::indexes($table);
+
+            FsmtpTest::assertSame(1, $addAttempts, 'replacement index creation attempt count');
+            FsmtpTest::assertSame(0, $dropAttempts, 'legacy index drop attempt count after replacement failure');
+            FsmtpTest::assertSame(['status'], isset($indexes['status']) ? $indexes['status'] : null, 'legacy status index after replacement failure');
+            FsmtpTest::assert(!isset($indexes['created_at_status']), 'failed replacement index unexpectedly exists');
+        } finally {
+            remove_filter('query', $ddlFailure, PHP_INT_MAX);
+            $wpdb->suppress_errors($wasSuppressing);
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
     FsmtpTest::case('log pruning deletes only rows older than the cutoff in bounded batches', function () {
         global $wpdb;
         $table = FsmtpFactory::emailLogTable(false, true);

--- a/tests/integration/database-behavior.php
+++ b/tests/integration/database-behavior.php
@@ -1,0 +1,160 @@
+<?php
+
+use FluentMailMigrations\EmailLogs;
+
+require_once FLUENTMAIL_PLUGIN_PATH . 'database/migrations/EmailLogs.php';
+
+return function () {
+    FsmtpTest::case('2.3.0 log schema converges without losing status index coverage', function () {
+        global $wpdb;
+        $table = FsmtpFactory::emailLogTable(true, false);
+        $observations = [];
+
+        $observer = null;
+        $observer = function ($query) use (&$observer, &$observations, $table) {
+            if (stripos($query, 'ALTER TABLE') === false || strpos($query, $table) === false) {
+                return $query;
+            }
+
+            remove_filter('query', $observer, PHP_INT_MAX);
+            $indexes = FsmtpFactory::indexes($table);
+            add_filter('query', $observer, PHP_INT_MAX);
+
+            $hasStatusCoverage = false;
+            foreach ($indexes as $columns) {
+                if (in_array('status', $columns, true)) {
+                    $hasStatusCoverage = true;
+                    break;
+                }
+            }
+            $observations[] = $hasStatusCoverage;
+            return $query;
+        };
+
+        add_filter('query', $observer, PHP_INT_MAX);
+        try {
+            $method = new ReflectionMethod(EmailLogs::class, 'maybeUpgradeIndexes');
+            $method->setAccessible(true);
+            $method->invoke(null, $table);
+        } finally {
+            remove_filter('query', $observer, PHP_INT_MAX);
+        }
+
+        try {
+            $indexes = FsmtpFactory::indexes($table);
+            FsmtpTest::assertSame(
+                ['created_at', 'status'],
+                isset($indexes['created_at_status']) ? $indexes['created_at_status'] : null,
+                'replacement index columns'
+            );
+            FsmtpTest::assert(!isset($indexes['status']), 'legacy status index was not removed');
+            FsmtpTest::assertSame([true, true], $observations, 'status remained indexed before every DDL step');
+            FsmtpTest::assertSame('', (string) $wpdb->last_error, 'migration database error');
+        } finally {
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
+    FsmtpTest::case('log index upgrade is idempotent after convergence', function () {
+        global $wpdb;
+        $table = FsmtpFactory::emailLogTable(false, true);
+        $alters = 0;
+        $observer = function ($query) use (&$alters, $table) {
+            if (stripos($query, 'ALTER TABLE') !== false && strpos($query, $table) !== false) {
+                $alters++;
+            }
+            return $query;
+        };
+
+        add_filter('query', $observer, PHP_INT_MAX);
+        try {
+            $method = new ReflectionMethod(EmailLogs::class, 'maybeUpgradeIndexes');
+            $method->setAccessible(true);
+            $method->invoke(null, $table);
+            $method->invoke(null, $table);
+
+            FsmtpTest::assertSame(0, $alters, 'converged schema emitted no ALTER TABLE statements');
+            FsmtpTest::assertSame('', (string) $wpdb->last_error, 'idempotent migration database error');
+        } finally {
+            remove_filter('query', $observer, PHP_INT_MAX);
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
+    FsmtpTest::case('log pruning deletes only rows older than the cutoff in bounded batches', function () {
+        global $wpdb;
+        $table = FsmtpFactory::emailLogTable(false, true);
+        $days = 14;
+        $cutoff = gmdate('Y-m-d H:i:s', current_time('timestamp') - $days * DAY_IN_SECONDS);
+
+        for ($index = 1; $index <= 5; $index++) {
+            FsmtpFactory::insertLog($table, [
+                'subject' => 'old-' . $index,
+                'created_at' => gmdate('Y-m-d H:i:s', strtotime($cutoff . ' -2 hours -' . $index . ' minutes')),
+            ]);
+        }
+        // Keep fixtures comfortably away from a wall-clock second boundary so
+        // the test specifies cutoff behavior without becoming timing-sensitive.
+        FsmtpFactory::insertLog($table, ['subject' => 'newer-1', 'created_at' => gmdate('Y-m-d H:i:s', strtotime($cutoff . ' +2 hours'))]);
+        FsmtpFactory::insertLog($table, ['subject' => 'newer-2', 'created_at' => gmdate('Y-m-d H:i:s', strtotime($cutoff . ' +2 hours +1 minute'))]);
+        FsmtpFactory::insertLog($table, ['subject' => 'newer-3', 'created_at' => gmdate('Y-m-d H:i:s', strtotime($cutoff . ' +2 hours +2 minutes'))]);
+
+        $deleteQueries = 0;
+        $queryFuse = function ($query) use (&$deleteQueries, $table) {
+            if (stripos($query, 'DELETE FROM') !== false && strpos($query, $table) !== false) {
+                $deleteQueries++;
+                if ($deleteQueries > 10) {
+                    throw new RuntimeException('delete loop exceeded the 10-query safety fuse');
+                }
+            }
+            return $query;
+        };
+        $batchFilter = function () {
+            return 2;
+        };
+
+        add_filter('query', $queryFuse, PHP_INT_MAX);
+        add_filter('fluentmail_log_delete_batch_size', $batchFilter, PHP_INT_MAX);
+        try {
+            $deleted = FsmtpFactory::loggerForTable($table)->deleteLogsOlderThan($days);
+            $remainingOld = (int) $wpdb->get_var(
+                $wpdb->prepare("SELECT COUNT(*) FROM `{$table}` WHERE created_at < %s", $cutoff)
+            );
+            $remaining = (int) $wpdb->get_var("SELECT COUNT(*) FROM `{$table}`");
+
+            FsmtpTest::assertSame(5, $deleted, 'deleted old row count');
+            FsmtpTest::assertSame(0, $remainingOld, 'no old fixtures remain');
+            FsmtpTest::assertSame(3, $remaining, 'newer fixtures remain');
+            FsmtpTest::assertSame(3, $deleteQueries, 'five rows were deleted in 2/2/1 batches');
+        } finally {
+            remove_filter('query', $queryFuse, PHP_INT_MAX);
+            remove_filter('fluentmail_log_delete_batch_size', $batchFilter, PHP_INT_MAX);
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
+    FsmtpTest::case('log pruning stops after one query when no row matches', function () {
+        $table = FsmtpFactory::emailLogTable(false, true);
+        FsmtpFactory::insertLog($table, ['created_at' => current_time('mysql', true)]);
+        $deleteQueries = 0;
+        $queryFuse = function ($query) use (&$deleteQueries, $table) {
+            if (stripos($query, 'DELETE FROM') !== false && strpos($query, $table) !== false) {
+                $deleteQueries++;
+                if ($deleteQueries > 10) {
+                    throw new RuntimeException('delete loop exceeded the 10-query safety fuse');
+                }
+            }
+            return $query;
+        };
+
+        add_filter('query', $queryFuse, PHP_INT_MAX);
+        try {
+            $deleted = FsmtpFactory::loggerForTable($table)->deleteLogsOlderThan(14);
+            FsmtpTest::assertSame(0, $deleted, 'no matching row was deleted');
+            FsmtpTest::assertSame(1, $deleteQueries, 'no-match pruning issued one DELETE then stopped');
+        } finally {
+            remove_filter('query', $queryFuse, PHP_INT_MAX);
+            FsmtpFactory::dropTable($table);
+        }
+    });
+};

--- a/tests/integration/domain-invariants.php
+++ b/tests/integration/domain-invariants.php
@@ -1,0 +1,441 @@
+<?php
+
+use FluentMail\App\Hooks\Handlers\BulkSendSessionHandler;
+use FluentMail\App\Hooks\Handlers\SchedulerHandler;
+
+/** Outbound SMTP socket seam; no network connection is ever opened. */
+class FsmtpSuiteSmtpConnection
+{
+    public $isConnected = false;
+
+    public function connected()
+    {
+        return $this->isConnected;
+    }
+}
+
+/** Minimum PHPMailer seam used by BulkSendSessionHandler. */
+class FsmtpSuiteBulkPhpMailer
+{
+    public $SMTPKeepAlive = false;
+    public $closeCalls = 0;
+    public $smtp;
+
+    public function __construct()
+    {
+        $this->smtp = new FsmtpSuiteSmtpConnection();
+    }
+
+    public function getSMTPInstance()
+    {
+        return $this->smtp;
+    }
+
+    public function smtpClose()
+    {
+        if ($this->smtp->isConnected) {
+            $this->closeCalls++;
+        }
+        $this->smtp->isConnected = false;
+    }
+}
+
+class FsmtpSuiteFailedHandler
+{
+    public $getPhpMailerCalls = 0;
+    private $phpMailer;
+
+    public function __construct($phpMailer = null)
+    {
+        $this->phpMailer = $phpMailer;
+    }
+
+    public function getPhpMailer()
+    {
+        $this->getPhpMailerCalls++;
+        return $this->phpMailer;
+    }
+}
+
+// The Google client is an outbound provider seam. Keeping the same class name
+// as connection-behavior.php lets this file run both alone and in the full tier.
+if (!class_exists('FsmtpSuiteGoogleClient', false)) {
+    class FsmtpSuiteGoogleClient
+    {
+        public static $tokens = [];
+
+        public function setClientId($value) {}
+        public function setClientSecret($value) {}
+        public function addScope($value) {}
+        public function setAccessType($value) {}
+        public function setApprovalPrompt($value) {}
+        public function setAccessToken($value) {}
+        public function refreshToken($value) { return self::$tokens; }
+    }
+}
+
+if (!class_exists('FluentSmtpLib\\Google\\Client', false)) {
+    class_alias(FsmtpSuiteGoogleClient::class, 'FluentSmtpLib\\Google\\Client');
+}
+
+return function () {
+    /**
+     * Isolate BulkSendSessionHandler's process-wide state and global mailer.
+     * The production handler is exercised while only the outbound socket is fake.
+     */
+    $withBulkState = function (callable $callback) {
+        global $phpmailer;
+
+        $hadPhpMailer = isset($phpmailer);
+        $originalPhpMailer = $hadPhpMailer ? $phpmailer : null;
+        $class = new ReflectionClass(BulkSendSessionHandler::class);
+        $propertyNames = [
+            'active',
+            'activeSince',
+            'hooked',
+            'connectionFingerprint',
+            'connectionOpenedAt',
+            'socketReused',
+        ];
+        $properties = [];
+        $originalValues = [];
+
+        foreach ($propertyNames as $name) {
+            $property = $class->getProperty($name);
+            $property->setAccessible(true);
+            $properties[$name] = $property;
+            $originalValues[$name] = $property->getValue(null);
+        }
+
+        $properties['active']->setValue(null, false);
+        $properties['activeSince']->setValue(null, 0);
+        // Avoid registering test callbacks in the process shutdown list.
+        $properties['hooked']->setValue(null, true);
+        $properties['connectionFingerprint']->setValue(null, null);
+        $properties['connectionOpenedAt']->setValue(null, 0);
+        $properties['socketReused']->setValue(null, false);
+
+        $phpmailer = new FsmtpSuiteBulkPhpMailer();
+        $keepAliveEnabled = function () {
+            return true;
+        };
+        add_filter('fluentmail_smtp_bulk_keep_alive', $keepAliveEnabled, PHP_INT_MAX);
+
+        try {
+            return $callback($phpmailer, $properties);
+        } finally {
+            remove_filter('fluentmail_smtp_bulk_keep_alive', $keepAliveEnabled, PHP_INT_MAX);
+            (new BulkSendSessionHandler())->endSession();
+
+            foreach ($properties as $name => $property) {
+                $property->setValue(null, $originalValues[$name]);
+            }
+
+            if ($hadPhpMailer) {
+                $phpmailer = $originalPhpMailer;
+            } else {
+                unset($phpmailer);
+            }
+        }
+    };
+
+    /**
+     * Supply deterministic settings while fusing every option write. This uses
+     * WordPress's real option API and refreshes FluentSMTP's own static cache.
+     */
+    $withSettings = function (array $settings, callable $callback) {
+        global $wpdb;
+
+        $optionNames = [
+            'fluentmail-settings',
+            '_fluent_smtp_notify_settings',
+            '_fsmtp_last_notification_sent',
+            \FluentMail\App\Services\ConnectionHealth::OPTION_KEY,
+        ];
+        $readOptions = function () use ($wpdb, $optionNames) {
+            $snapshot = [];
+            foreach ($optionNames as $name) {
+                $snapshot[$name] = $wpdb->get_row(
+                    $wpdb->prepare(
+                        "SELECT option_value, autoload FROM {$wpdb->options} WHERE option_name = %s",
+                        $name
+                    ),
+                    ARRAY_A
+                );
+            }
+            return $snapshot;
+        };
+
+        $before = $readOptions();
+        $settingsFilter = function () use ($settings) {
+            return $settings;
+        };
+        $notificationFilter = function () {
+            return [
+                'enabled'        => 'no',
+                'notify_email'   => '',
+                'notify_days'    => [],
+                'active_channel' => [],
+            ];
+        };
+        $writeFuse = function ($newValue, $oldValue) {
+            return $oldValue;
+        };
+
+        add_filter('pre_option_fluentmail-settings', $settingsFilter, PHP_INT_MAX);
+        add_filter('pre_option__fluent_smtp_notify_settings', $notificationFilter, PHP_INT_MAX);
+        foreach ($optionNames as $name) {
+            add_filter('pre_update_option_' . $name, $writeFuse, PHP_INT_MAX, 2);
+        }
+
+        wp_cache_delete('fluentmail-settings', 'options');
+        fluentMailGetSettings([], false);
+
+        try {
+            return $callback();
+        } finally {
+            remove_filter('pre_option_fluentmail-settings', $settingsFilter, PHP_INT_MAX);
+            remove_filter('pre_option__fluent_smtp_notify_settings', $notificationFilter, PHP_INT_MAX);
+            foreach ($optionNames as $name) {
+                remove_filter('pre_update_option_' . $name, $writeFuse, PHP_INT_MAX);
+                wp_cache_delete($name, 'options');
+            }
+            wp_cache_delete('alloptions', 'options');
+            fluentMailGetSettings([], false);
+
+            FsmtpTest::assertSame($before, $readOptions(), 'domain invariant option fuses');
+        }
+    };
+
+    $baseSettings = function () {
+        return [
+            'connections' => [],
+            'mappings'    => [],
+            'misc'        => [
+                'simulate_emails'         => 'yes',
+                'log_emails'              => 'no',
+                'log_saved_interval_days' => '0',
+                'default_connection'      => '',
+                'fallback_connection'     => '',
+            ],
+        ];
+    };
+
+    FsmtpTest::case('bulk SMTP session start and end own the kept-alive socket lifecycle', function () use ($withBulkState) {
+        $withBulkState(function ($mailer) {
+            $handler = new BulkSendSessionHandler();
+            $mailer->smtp->isConnected = true;
+            $mailer->SMTPKeepAlive = true;
+
+            $handler->startSession();
+            FsmtpTest::assert(BulkSendSessionHandler::isActive(), 'bulk session did not become active');
+
+            $handler->endSession();
+            FsmtpTest::assert(!BulkSendSessionHandler::isActive(), 'bulk session remained active after end');
+            FsmtpTest::assertSame(1, $mailer->closeCalls, 'session end SMTP close count');
+            FsmtpTest::assertSame(false, $mailer->SMTPKeepAlive, 'session end keep-alive flag');
+        });
+    });
+
+    FsmtpTest::case('bulk SMTP session reuses only a live socket with the same connection identity', function () use ($withBulkState) {
+        $withBulkState(function ($mailer) {
+            $handler = new BulkSendSessionHandler();
+            $connectionA = ['host' => 'smtp-a.example.test', 'port' => 2525, 'auth_key' => 'a'];
+            $connectionB = ['host' => 'smtp-b.example.test', 'port' => 2525, 'auth_key' => 'b'];
+
+            $handler->startSession();
+            BulkSendSessionHandler::ensureConnectionFor($connectionA);
+            $mailer->smtp->isConnected = true;
+
+            BulkSendSessionHandler::ensureConnectionFor($connectionA);
+            FsmtpTest::assertSame(0, $mailer->closeCalls, 'matching connection close count');
+            FsmtpTest::assertSame(true, BulkSendSessionHandler::wasSocketReused(), 'matching socket reuse flag');
+
+            BulkSendSessionHandler::ensureConnectionFor($connectionB);
+            FsmtpTest::assertSame(1, $mailer->closeCalls, 'changed connection close count');
+            FsmtpTest::assertSame(false, BulkSendSessionHandler::wasSocketReused(), 'changed connection reuse flag');
+        });
+    });
+
+    FsmtpTest::case('bulk SMTP session recycles a socket at the maximum connection age', function () use ($withBulkState) {
+        $withBulkState(function ($mailer, $properties) {
+            $handler = new BulkSendSessionHandler();
+            $connection = ['host' => 'smtp-age.example.test', 'port' => 2525, 'auth_key' => 'age'];
+
+            $handler->startSession();
+            BulkSendSessionHandler::ensureConnectionFor($connection);
+            $mailer->smtp->isConnected = true;
+            $properties['connectionOpenedAt']->setValue(
+                null,
+                time() - BulkSendSessionHandler::MAX_CONNECTION_AGE
+            );
+
+            BulkSendSessionHandler::ensureConnectionFor($connection);
+            FsmtpTest::assertSame(1, $mailer->closeCalls, 'aged connection close count');
+            FsmtpTest::assertSame(false, BulkSendSessionHandler::wasSocketReused(), 'aged connection reuse flag');
+        });
+    });
+
+    FsmtpTest::case('failed mail without a configured fallback routes to the no-fallback action', function () use (
+        $baseSettings,
+        $withSettings
+    ) {
+        $settings = $baseSettings();
+        $handler = new FsmtpSuiteFailedHandler();
+        $observed = [];
+        $observer = function ($logId, $failedHandler, $data) use (&$observed) {
+            $observed[] = [$logId, $failedHandler, $data];
+        };
+        add_action('fluentmail_email_sending_failed_no_fallback', $observer, PHP_INT_MAX, 3);
+
+        try {
+            $withSettings($settings, function () use ($handler, &$observed) {
+                $data = ['response' => 'suite failure'];
+                $result = (new SchedulerHandler())->maybeHandleFallbackConnection(false, 987654321, $handler, $data);
+
+                FsmtpTest::assertSame(false, $result, 'no-fallback return value');
+                FsmtpTest::assertSame(0, $handler->getPhpMailerCalls, 'no-fallback mailer access count');
+                FsmtpTest::assertSame(1, count($observed), 'no-fallback action count');
+                $action = isset($observed[0]) ? $observed[0] : [null, null, null];
+                FsmtpTest::assertSame(987654321, $action[0], 'no-fallback log ID');
+                FsmtpTest::assertSame($handler, $action[1], 'no-fallback handler');
+                FsmtpTest::assertSame($data, $action[2], 'no-fallback data');
+            });
+        } finally {
+            remove_action('fluentmail_email_sending_failed_no_fallback', $observer, PHP_INT_MAX);
+        }
+    });
+
+    FsmtpTest::case('configured fallback rewrites the sender and dispatches through Simulator', function () use (
+        $baseSettings,
+        $withSettings
+    ) {
+        global $wpdb;
+
+        if (!class_exists('PHPMailer\\PHPMailer\\PHPMailer')) {
+            require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
+            require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+            require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
+        }
+
+        $fallbackEmail = 'fallback-' . FsmtpTest::uniq() . '@example.test';
+        $settings = $baseSettings();
+        $settings['misc']['fallback_connection'] = 'suite-fallback';
+        $settings['connections']['suite-fallback'] = [
+            'title' => 'Suite Fallback',
+            'provider_settings' => [
+                'provider'     => 'smtp',
+                'sender_email' => $fallbackEmail,
+            ],
+        ];
+
+        $beforeCounts = FsmtpTest::protectedTableCounts();
+        $wpdb->query('START TRANSACTION');
+        try {
+            $table = $wpdb->prefix . 'fsmpt_email_logs';
+            $logId = FsmtpFactory::insertLog($table, [
+                'subject'  => 'fallback source ' . FsmtpTest::uniq(),
+                'body'     => 'source body',
+                'headers'  => maybe_serialize([]),
+                'response' => maybe_serialize(['message' => 'primary failed']),
+                'extra'    => maybe_serialize(['provider' => 'Suite Primary']),
+                'status'   => 'failed',
+            ]);
+
+            $phpMailer = new \PHPMailer\PHPMailer\PHPMailer(true);
+            $phpMailer->CharSet = 'UTF-8';
+            $phpMailer->setFrom('primary-' . FsmtpTest::uniq() . '@example.test', 'Suite Primary');
+            $phpMailer->addAddress('recipient@example.test');
+            $phpMailer->Subject = 'Suite fallback message';
+            $phpMailer->Body = 'Suite fallback body';
+            $handler = new FsmtpSuiteFailedHandler($phpMailer);
+
+            $withSettings($settings, function () use ($handler, $phpMailer, $logId, $fallbackEmail, $wpdb, $table) {
+                $beforeRows = (int)$wpdb->get_var("SELECT COUNT(*) FROM `{$table}`");
+                $result = (new SchedulerHandler())->maybeHandleFallbackConnection(false, $logId, $handler, []);
+                $afterRows = (int)$wpdb->get_var("SELECT COUNT(*) FROM `{$table}`");
+                $simulated = $wpdb->get_row("SELECT `from`, extra FROM `{$table}` ORDER BY id DESC LIMIT 1", ARRAY_A);
+                $extra = maybe_unserialize($simulated['extra']);
+
+                FsmtpTest::assertSame(true, $result, 'configured fallback result');
+                FsmtpTest::assertSame(1, $handler->getPhpMailerCalls, 'configured fallback mailer access count');
+                FsmtpTest::assertSame($fallbackEmail, $phpMailer->From, 'configured fallback sender');
+                FsmtpTest::assertSame($beforeRows + 1, $afterRows, 'Simulator fallback fixture row count');
+                FsmtpTest::assertSame('Simulator', $extra['provider'], 'fallback provider seam');
+            });
+        } finally {
+            $wpdb->query('ROLLBACK');
+        }
+
+        FsmtpTest::assertSame($beforeCounts, FsmtpTest::protectedTableCounts(), 'fallback transaction cleanup');
+    });
+
+    FsmtpTest::case('daily health pass re-arms Gmail renewal after a failed event ends the chain', function () use (
+        $baseSettings,
+        $withSettings
+    ) {
+        $sender = 'gmail-rearm-' . FsmtpTest::uniq() . '@example.test';
+        $connectionKey = md5($sender);
+        $settings = $baseSettings();
+        $settings['connections'][$connectionKey] = [
+            'title' => 'Suite Gmail Re-arm',
+            'provider_settings' => [
+                'provider'      => 'gmail',
+                'sender_email'  => $sender,
+                'key_store'     => 'db',
+                'client_id'     => 'suite-client',
+                'client_secret' => 'suite-secret',
+                'access_token'  => 'expired-access-token',
+                'refresh_token' => 'suite-refresh-token',
+                'expire_stamp'  => time() - 60,
+            ],
+        ];
+        $settings['mappings'][$sender] = $connectionKey;
+        $settings['misc']['default_connection'] = $connectionKey;
+
+        $scheduled = [];
+        $scheduleFuse = function ($pre, $event) use (&$scheduled) {
+            $scheduled[] = [
+                'hook'      => $event->hook,
+                'timestamp' => $event->timestamp,
+            ];
+            return false;
+        };
+        add_filter('pre_schedule_event', $scheduleFuse, PHP_INT_MAX, 3);
+
+        $beforeCron = wp_next_scheduled('fluentsmtp_renew_gmail_token');
+        try {
+            $withSettings($settings, function () use (&$scheduled) {
+                $scheduler = new SchedulerHandler();
+                FsmtpSuiteGoogleClient::$tokens = [
+                    'error'             => 'invalid_grant',
+                    'error_description' => 'Suite transient renewal failure',
+                ];
+
+                $scheduler->renewGmailToken();
+                FsmtpTest::assertSame([], $scheduled, 'failed renewal scheduled events');
+
+                FsmtpSuiteGoogleClient::$tokens = [
+                    'access_token'  => 'suite-rearmed-access',
+                    'refresh_token' => 'suite-rearmed-refresh',
+                    'expires_in'    => 3600,
+                ];
+                $startedAt = time();
+                $scheduler->handleScheduledJobs();
+
+                FsmtpTest::assertSame(1, count($scheduled), 'daily health re-arm event count');
+                $event = isset($scheduled[0]) ? $scheduled[0] : ['hook' => null, 'timestamp' => 0];
+                FsmtpTest::assertSame('fluentsmtp_renew_gmail_token', $event['hook'], 'daily health re-arm hook');
+                FsmtpTest::assert(
+                    $event['timestamp'] >= $startedAt + 3200
+                    && $event['timestamp'] <= time() + 3300,
+                    'daily health re-arm timestamp was not based on the renewed token expiry'
+                );
+            });
+        } finally {
+            remove_filter('pre_schedule_event', $scheduleFuse, PHP_INT_MAX);
+        }
+
+        FsmtpTest::assertSame($beforeCron, wp_next_scheduled('fluentsmtp_renew_gmail_token'), 'OAuth cron state');
+    });
+};

--- a/tests/integration/environment-axes.php
+++ b/tests/integration/environment-axes.php
@@ -1,0 +1,341 @@
+<?php
+
+use FluentMail\App\Hooks\Handlers\AdminMenuHandler;
+use FluentMail\App\Services\Reporting;
+
+return function () {
+    /** Prove the requested process-local timezone is the clock under test. */
+    $assertTimezoneAxis = function () {
+        $requested = getenv('FSMTP_TEST_GMT_OFFSET');
+        if ($requested === false || $requested === '') {
+            return;
+        }
+
+        FsmtpTest::assertSame((float)$requested, (float)get_option('gmt_offset'), 'active gmt_offset axis');
+        FsmtpTest::assertSame('', (string)get_option('timezone_string'), 'numeric-offset timezone axis');
+    };
+
+    /** Run hard-coded production log queries against an isolated real table. */
+    $redirectFixture = function ($table, callable $callback) {
+        $redirect = FsmtpFactory::productionLogTableRedirect($table);
+        add_filter('query', $redirect, PHP_INT_MAX);
+        try {
+            return $callback();
+        } finally {
+            remove_filter('query', $redirect, PHP_INT_MAX);
+        }
+    };
+
+    /** Convert dashboard widget table rows to title => [sent, failed]. */
+    $widgetRows = function ($html) {
+        $document = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        try {
+            $document->loadHTML('<?xml encoding="utf-8" ?>' . $html);
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+
+        $rows = [];
+        foreach ($document->getElementsByTagName('tbody')->item(0)->getElementsByTagName('tr') as $row) {
+            $cells = $row->getElementsByTagName('td');
+            $rows[trim($cells->item(0)->textContent)] = [
+                (int)trim($cells->item(1)->textContent),
+                (int)trim($cells->item(2)->textContent),
+            ];
+        }
+        return $rows;
+    };
+
+    /** Enable strict modes for this connection and return its prior value. */
+    $enableStrictSql = function () {
+        global $wpdb;
+        $before = (string)$wpdb->get_var('SELECT @@SESSION.sql_mode');
+        $modes = array_values(array_unique(array_merge(
+            array_filter(array_map('trim', explode(',', $before))),
+            ['ONLY_FULL_GROUP_BY', 'STRICT_TRANS_TABLES']
+        )));
+        $result = $wpdb->query($wpdb->prepare('SET SESSION sql_mode = %s', implode(',', $modes)));
+        if ($result === false) {
+            throw new RuntimeException('Could not enable strict SQL modes: ' . $wpdb->last_error);
+        }
+        return $before;
+    };
+
+    $restoreSqlMode = function ($mode) {
+        global $wpdb;
+        $result = $wpdb->query($wpdb->prepare('SET SESSION sql_mode = %s', $mode));
+        if ($result === false) {
+            throw new RuntimeException('Could not restore SQL mode: ' . $wpdb->last_error);
+        }
+    };
+
+    /** Create strict-mode fixtures and restore both table and session exactly. */
+    $withStrictFixture = function (callable $callback) use ($enableStrictSql, $restoreSqlMode) {
+        $beforeMode = $enableStrictSql();
+        $table = FsmtpFactory::emailLogTable(false, true);
+        $rows = [
+            ['status' => 'sent', 'subject' => 'alpha', 'created_at' => '2025-01-06 10:00:00'],
+            ['status' => 'sent', 'subject' => 'alpha', 'created_at' => '2025-01-07 11:00:00'],
+            ['status' => 'failed', 'subject' => 'beta', 'created_at' => '2025-03-01 12:00:00'],
+            ['status' => 'sent', 'subject' => 'gamma', 'created_at' => '2025-08-01 13:00:00'],
+        ];
+        foreach ($rows as $row) {
+            FsmtpFactory::insertLog($table, $row);
+        }
+
+        try {
+            return $callback($table);
+        } finally {
+            FsmtpFactory::dropTable($table);
+            $restoreSqlMode($beforeMode);
+        }
+    };
+
+    FsmtpTest::case('log pruning uses the site-local retention cutoff at non-UTC offsets', function () use ($assertTimezoneAxis) {
+        global $wpdb;
+        $assertTimezoneAxis();
+
+        $table = FsmtpFactory::emailLogTable(false, true);
+        $days = 14;
+        $cutoff = current_datetime()->sub(new DateInterval('P' . $days . 'D'));
+        $oldId = FsmtpFactory::insertLog($table, [
+            'subject' => 'site-local-old',
+            'created_at' => $cutoff->modify('-2 hours')->format('Y-m-d H:i:s'),
+        ]);
+        $newId = FsmtpFactory::insertLog($table, [
+            'subject' => 'site-local-new',
+            'created_at' => $cutoff->modify('+2 hours')->format('Y-m-d H:i:s'),
+        ]);
+
+        try {
+            $deleted = FsmtpFactory::loggerForTable($table)->deleteLogsOlderThan($days);
+            $remaining = array_map('intval', $wpdb->get_col("SELECT id FROM `{$table}` ORDER BY id"));
+
+            FsmtpTest::assertSame(1, $deleted, 'site-local expired row count');
+            FsmtpTest::assertSame([$newId], $remaining, 'site-local retained row IDs');
+            FsmtpTest::assert(!in_array($oldId, $remaining, true), 'expired row survived the site-local cutoff');
+        } finally {
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
+    FsmtpTest::case('dashboard widget counters use the site-local midnight boundary', function () use (
+        $assertTimezoneAxis,
+        $redirectFixture,
+        $widgetRows
+    ) {
+        $assertTimezoneAxis();
+        $table = FsmtpFactory::emailLogTable(false, true);
+        $today = current_datetime()->setTime(0, 0, 0);
+        FsmtpFactory::insertLog($table, [
+            'status' => 'sent',
+            'created_at' => $today->modify('-30 minutes')->format('Y-m-d H:i:s'),
+        ]);
+        FsmtpFactory::insertLog($table, [
+            'status' => 'sent',
+            'created_at' => $today->modify('+30 minutes')->format('Y-m-d H:i:s'),
+        ]);
+        FsmtpFactory::insertLog($table, [
+            'status' => 'failed',
+            'created_at' => $today->modify('+45 minutes')->format('Y-m-d H:i:s'),
+        ]);
+
+        try {
+            $html = $redirectFixture($table, function () {
+                $handler = new AdminMenuHandler(fluentMail());
+                $method = new ReflectionMethod($handler, 'getDashboardWidgetHtml');
+                $method->setAccessible(true);
+                return $method->invoke($handler);
+            });
+            $rows = $widgetRows($html);
+
+            FsmtpTest::assertSame([1, 1], isset($rows['Today']) ? $rows['Today'] : null, 'site-local Today counters');
+            FsmtpTest::assertSame([2, 1], isset($rows['All']) ? $rows['All'] : null, 'isolated all-time counters');
+        } finally {
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
+    FsmtpTest::case('report chart buckets rows by their site-local calendar day', function () use (
+        $assertTimezoneAxis,
+        $redirectFixture
+    ) {
+        $assertTimezoneAxis();
+        $table = FsmtpFactory::emailLogTable(false, true);
+        $today = current_datetime()->setTime(0, 0, 0);
+        $previous = $today->modify('-1 day');
+        FsmtpFactory::insertLog($table, ['created_at' => $previous->setTime(23, 30)->format('Y-m-d H:i:s')]);
+        FsmtpFactory::insertLog($table, ['created_at' => $today->setTime(0, 30)->format('Y-m-d H:i:s')]);
+        FsmtpFactory::insertLog($table, ['created_at' => $today->setTime(12, 0)->format('Y-m-d H:i:s')]);
+
+        try {
+            $stats = $redirectFixture($table, function () use ($previous, $today) {
+                return (new Reporting())->getSendingStats(
+                    $previous->format('Y-m-d'),
+                    $today->format('Y-m-d')
+                );
+            });
+
+            FsmtpTest::assertSame(1, isset($stats[$previous->format('Y-m-d')]) ? $stats[$previous->format('Y-m-d')] : null, 'previous-day chart bucket');
+            FsmtpTest::assertSame(2, isset($stats[$today->format('Y-m-d')]) ? $stats[$today->format('Y-m-d')] : null, 'today chart bucket');
+        } finally {
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
+    FsmtpTest::case('day-time heatmap buckets rows by site-local weekday and hour', function () use (
+        $assertTimezoneAxis,
+        $redirectFixture
+    ) {
+        $assertTimezoneAxis();
+        $table = FsmtpFactory::emailLogTable(false, true);
+        $today = current_datetime()->setTime(0, 0, 0);
+        $previous = $today->modify('-1 day');
+        FsmtpFactory::insertLog($table, ['created_at' => $previous->setTime(23, 30)->format('Y-m-d H:i:s')]);
+        FsmtpFactory::insertLog($table, ['created_at' => $today->setTime(0, 15)->format('Y-m-d H:i:s')]);
+        FsmtpFactory::insertLog($table, ['created_at' => $today->setTime(0, 45)->format('Y-m-d H:i:s')]);
+
+        try {
+            $result = $redirectFixture($table, function () {
+                return FsmtpTest::ajax('GET', '/day-time-stats', ['last_day' => 0]);
+            });
+            $strictFailure = strpos($result['db_error'], 'ORDER BY clause is not in GROUP BY clause') !== false
+                && strpos($result['db_error'], 'only_full_group_by') !== false;
+            if (FsmtpTest::knownFailure(
+                $strictFailure,
+                'heatmap ordering is rejected by ONLY_FULL_GROUP_BY while exercising the timezone axis (app/Http/Controllers/DashboardController.php:79-81).'
+            )) {
+                return;
+            }
+            FsmtpTest::assertAjaxHealthy($result, 'site-local day-time heatmap');
+            $stats = isset($result['data']['stats']) ? $result['data']['stats'] : [];
+
+            FsmtpTest::assertSame(1, isset($stats[$previous->format('D')]['23:00']) ? $stats[$previous->format('D')]['23:00'] : null, 'previous-day heatmap bucket');
+            FsmtpTest::assertSame(2, isset($stats[$today->format('D')]['0:00']) ? $stats[$today->format('D')]['0:00'] : null, 'today heatmap bucket');
+        } finally {
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
+    FsmtpTest::case('Logger aggregates return exact values under strict SQL modes', function () use ($withStrictFixture) {
+        global $wpdb;
+        $withStrictFixture(function ($table) use ($wpdb) {
+            $logger = FsmtpFactory::loggerForTable($table);
+            FsmtpTest::assertSame(['sent' => '3', 'failed' => '1'], $logger->getStats(), 'status aggregate');
+            FsmtpTest::assertSame(2, $logger->getTotalCountStat('sent', '2025-01-01', '2025-01-31'), 'bounded status aggregate');
+            FsmtpTest::assertSame(1, $logger->getTotalCountStat('failed', '2025-02-01'), 'open-ended status aggregate');
+            FsmtpTest::assertSame(1, $logger->getSubjectCountStat('sent', '2025-01-01', '2025-01-31'), 'distinct-subject aggregate');
+            $subjects = $logger->getSubjectStat('sent', '2025-01-01', '2025-12-31', 5);
+            FsmtpTest::assertSame('alpha', isset($subjects[0]['subject']) ? $subjects[0]['subject'] : null, 'grouped subject leader');
+            FsmtpTest::assertSame('2', isset($subjects[0]['emails_sent']) ? $subjects[0]['emails_sent'] : null, 'grouped subject count');
+            FsmtpTest::assertSame('', (string)$wpdb->last_error, 'Logger strict aggregate database error');
+
+            $activeModes = array_map('strtoupper', explode(',', (string)$wpdb->get_var('SELECT @@SESSION.sql_mode')));
+            FsmtpTest::assert(in_array('ONLY_FULL_GROUP_BY', $activeModes, true), 'ONLY_FULL_GROUP_BY was not active');
+            FsmtpTest::assert(in_array('STRICT_TRANS_TABLES', $activeModes, true), 'STRICT_TRANS_TABLES was not active');
+        });
+    });
+
+    FsmtpTest::case('daily report aggregate returns values under strict SQL modes', function () use (
+        $withStrictFixture,
+        $redirectFixture
+    ) {
+        global $wpdb;
+        $withStrictFixture(function ($table) use ($wpdb, $redirectFixture) {
+            $stats = $redirectFixture($table, function () {
+                return (new Reporting())->getSendingStats('2025-01-06', '2025-01-10');
+            });
+
+            FsmtpTest::assertSame('', (string)$wpdb->last_error, 'daily report strict database error');
+            FsmtpTest::assertSame(1, isset($stats['2025-01-06']) ? $stats['2025-01-06'] : null, 'strict daily report first bucket');
+            FsmtpTest::assertSame(1, isset($stats['2025-01-07']) ? $stats['2025-01-07'] : null, 'strict daily report second bucket');
+        });
+    });
+
+    FsmtpTest::case('weekly report aggregate is tracked under strict SQL modes', function () use (
+        $withStrictFixture,
+        $redirectFixture
+    ) {
+        global $wpdb;
+        $withStrictFixture(function ($table) use ($wpdb, $redirectFixture) {
+            $wasSuppressing = $wpdb->suppress_errors();
+            try {
+                $stats = $redirectFixture($table, function () {
+                    return (new Reporting())->getSendingStats('2025-01-01', '2025-04-30');
+                });
+                $error = (string)$wpdb->last_error;
+            } finally {
+                $wpdb->suppress_errors($wasSuppressing);
+            }
+
+            $known = strpos($error, 'not in GROUP BY clause') !== false
+                && strpos($error, 'only_full_group_by') !== false;
+            if (!FsmtpTest::knownFailure(
+                $known,
+                'Reporting weekly SELECT is rejected by ONLY_FULL_GROUP_BY (app/Services/Reporting.php:40,58).'
+            )) {
+                FsmtpTest::assertSame('', $error, 'weekly report strict database error');
+                FsmtpTest::assertSame(2, isset($stats['2025-01-06']) ? $stats['2025-01-06'] : null, 'strict weekly report bucket');
+            }
+        });
+    });
+
+    FsmtpTest::case('monthly report aggregate is tracked under strict SQL modes', function () use (
+        $withStrictFixture,
+        $redirectFixture
+    ) {
+        global $wpdb;
+        $withStrictFixture(function ($table) use ($wpdb, $redirectFixture) {
+            $wasSuppressing = $wpdb->suppress_errors();
+            try {
+                $stats = $redirectFixture($table, function () {
+                    return (new Reporting())->getSendingStats('2025-01-01', '2025-12-31');
+                });
+                $error = (string)$wpdb->last_error;
+            } finally {
+                $wpdb->suppress_errors($wasSuppressing);
+            }
+
+            $known = strpos($error, 'not in GROUP BY clause') !== false
+                && strpos($error, 'only_full_group_by') !== false;
+            if (!FsmtpTest::knownFailure(
+                $known,
+                'Reporting monthly SELECT is rejected by ONLY_FULL_GROUP_BY (app/Services/Reporting.php:45,58).'
+            )) {
+                FsmtpTest::assertSame('', $error, 'monthly report strict database error');
+                FsmtpTest::assertSame(2, isset($stats['Jan 2025']) ? $stats['Jan 2025'] : null, 'strict monthly report bucket');
+            }
+        });
+    });
+
+    FsmtpTest::case('day-time heatmap aggregate is tracked under strict SQL modes', function () use (
+        $withStrictFixture,
+        $redirectFixture
+    ) {
+        global $wpdb;
+        $withStrictFixture(function ($table) use ($wpdb, $redirectFixture) {
+            $wasSuppressing = $wpdb->suppress_errors();
+            try {
+                $result = $redirectFixture($table, function () {
+                    return FsmtpTest::ajax('GET', '/day-time-stats', ['last_day' => 0]);
+                });
+                $error = (string)$result['db_error'];
+            } finally {
+                $wpdb->suppress_errors($wasSuppressing);
+            }
+
+            $known = strpos($error, 'ORDER BY clause is not in GROUP BY clause') !== false
+                && strpos($error, 'only_full_group_by') !== false;
+            if (!FsmtpTest::knownFailure(
+                $known,
+                'heatmap FIELD(DAYNAME(created_at)) ordering is rejected by ONLY_FULL_GROUP_BY (app/Http/Controllers/DashboardController.php:60-62,79-81).'
+            )) {
+                FsmtpTest::assertAjaxHealthy($result, 'strict heatmap aggregate');
+                $stats = isset($result['data']['stats']) ? $result['data']['stats'] : [];
+                FsmtpTest::assertSame(1, isset($stats['Mon']['10:00']) ? $stats['Mon']['10:00'] : null, 'strict heatmap bucket');
+            }
+        });
+    });
+};

--- a/tests/integration/environment-axes.php
+++ b/tests/integration/environment-axes.php
@@ -185,6 +185,25 @@ return function () {
         }
     });
 
+    FsmtpTest::case('report chart excludes rows immediately outside the requested range', function () use ($redirectFixture) {
+        $table = FsmtpFactory::emailLogTable(false, true);
+        FsmtpFactory::insertLog($table, ['created_at' => '2025-01-05 23:59:59']);
+        FsmtpFactory::insertLog($table, ['created_at' => '2025-01-07 12:00:00']);
+        FsmtpFactory::insertLog($table, ['created_at' => '2025-01-11 00:00:01']);
+
+        try {
+            $stats = $redirectFixture($table, function () {
+                return (new Reporting())->getSendingStats('2025-01-06', '2025-01-10');
+            });
+
+            FsmtpTest::assert(!isset($stats['2025-01-05']), 'row immediately before the report range contributed a bucket');
+            FsmtpTest::assert(!isset($stats['2025-01-11']), 'row immediately after the report range contributed a bucket');
+            FsmtpTest::assertSame(1, array_sum($stats), 'out-of-range rows contributed to the report count');
+        } finally {
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
     FsmtpTest::case('day-time heatmap buckets rows by site-local weekday and hour', function () use (
         $assertTimezoneAxis,
         $redirectFixture

--- a/tests/integration/input-validation.php
+++ b/tests/integration/input-validation.php
@@ -1,0 +1,192 @@
+<?php
+
+use FluentMail\App\Http\Controllers\LoggerController;
+use FluentMail\App\Models\Logger;
+use FluentMail\App\Services\Reporting;
+
+/** Force the parent reporting path to receive identifiers outside its whitelist. */
+class FsmtpSuiteUnlistedReporting extends Reporting
+{
+    protected function getGroupAndOrder($frequency)
+    {
+        return ['created_at', 'created_at'];
+    }
+}
+
+return function () {
+    /** Read one production method without hard-coding repository paths. */
+    $methodSource = function ($class, $method) {
+        $reflection = new ReflectionMethod($class, $method);
+        $lines = file($reflection->getFileName());
+        if ($lines === false) {
+            throw new RuntimeException('Could not read reflected production source.');
+        }
+
+        return implode('', array_slice(
+            $lines,
+            $reflection->getStartLine() - 1,
+            $reflection->getEndLine() - $reflection->getStartLine() + 1
+        ));
+    };
+
+    $compactSource = function ($source) {
+        return preg_replace('/\s+/', '', $source);
+    };
+
+    /** Query an isolated fixture through the same real builder used by Logger. */
+    $selectFixtureIds = function ($table, callable $scope) {
+        global $wpdb;
+
+        if (strpos($table, $wpdb->prefix) !== 0) {
+            throw new RuntimeException('Fixture table does not use the active WordPress prefix.');
+        }
+
+        $query = fluentMailDb()->table(substr($table, strlen($wpdb->prefix)));
+        $scope($query);
+
+        return array_map('intval', wp_list_pluck($query->get(), 'id'));
+    };
+
+    FsmtpTest::case('log navigation treats search wildcard characters as literals', function () {
+        $table = FsmtpFactory::emailLogTable();
+        $needle = FsmtpTest::uniq('literal') . '%_marker';
+        $literalId = FsmtpFactory::insertLog($table, [
+            'subject' => 'subject ' . $needle,
+        ]);
+        FsmtpFactory::insertLog($table, [
+            'subject' => 'subject ' . str_replace('%_', 'AB', $needle),
+        ]);
+
+        try {
+            $result = FsmtpFactory::loggerForTable($table)->navigate([
+                'query' => $needle,
+                'id'    => 0,
+                'dir'   => 'next',
+            ]);
+
+            FsmtpTest::assertSame($literalId, isset($result['log']['id']) ? $result['log']['id'] : null, 'literal wildcard search result');
+            FsmtpTest::assertSame(false, $result['next'], 'literal wildcard search did not match wildcard lookalike');
+        } finally {
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
+    FsmtpTest::case('day-time statistics clamp the requested lookback to 365 days', function () {
+        global $wpdb;
+
+        $table = $wpdb->prefix . 'fsmpt_email_logs';
+        $queries = [];
+        $observer = function ($query) use (&$queries, $table) {
+            if (stripos(ltrim($query), 'SELECT') === 0 && strpos($query, $table) !== false && strpos($query, 'DAYNAME(created_at)') !== false) {
+                $queries[] = $query;
+            }
+            return $query;
+        };
+
+        add_filter('query', $observer, PHP_INT_MAX);
+        try {
+            $result = FsmtpTest::ajax('GET', '/day-time-stats', ['last_day' => '999999']);
+        } finally {
+            remove_filter('query', $observer, PHP_INT_MAX);
+        }
+
+        FsmtpTest::assertAjaxHealthy($result, 'clamped day-time statistics');
+        FsmtpTest::assertSame(1, count($queries), 'day-time statistics SELECT count');
+        $query = isset($queries[0]) ? $queries[0] : '';
+        FsmtpTest::assert(strpos($query, 'INTERVAL 365 DAY') !== false, 'day-time lookback was not clamped to 365');
+        FsmtpTest::assert(strpos($query, '999999') === false, 'unclamped day-time lookback reached the SELECT');
+    });
+
+    FsmtpTest::case('sending statistics replace unlisted grouping columns with the daily whitelist fallback', function () {
+        global $wpdb;
+
+        $table = $wpdb->prefix . FLUENT_MAIL_DB_PREFIX . 'email_logs';
+        $queries = [];
+        $observer = function ($query) use (&$queries, $table) {
+            if (stripos(ltrim($query), 'SELECT') === 0 && strpos($query, $table) !== false && strpos($query, 'GROUP BY') !== false) {
+                $queries[] = $query;
+            }
+            return $query;
+        };
+
+        add_filter('query', $observer, PHP_INT_MAX);
+        try {
+            (new FsmtpSuiteUnlistedReporting())->getSendingStats('-7 days', 'today');
+        } finally {
+            remove_filter('query', $observer, PHP_INT_MAX);
+        }
+
+        FsmtpTest::assertSame('', (string) $wpdb->last_error, 'whitelisted reporting database error');
+        FsmtpTest::assertSame(1, count($queries), 'sending statistics SELECT count');
+        $query = isset($queries[0]) ? $queries[0] : '';
+        FsmtpTest::assert(strpos($query, 'GROUP BY `date`') !== false, 'unlisted reporting group did not fall back to date');
+        FsmtpTest::assert(strpos($query, 'ORDER BY `date` ASC') !== false, 'unlisted reporting order did not fall back to date');
+        FsmtpTest::assert(strpos($query, 'GROUP BY `created_at`') === false, 'unlisted reporting group reached the SELECT');
+    });
+
+    FsmtpTest::case('log retry lookup remains scoped to the requested ID', function () use ($methodSource, $compactSource, $selectFixtureIds) {
+        $controllerSource = $compactSource($methodSource(LoggerController::class, 'retry'));
+        $resendSource = $compactSource($methodSource(Logger::class, 'resendEmailFromLog'));
+        $findSource = $compactSource($methodSource(Logger::class, 'find'));
+
+        FsmtpTest::assert(
+            strpos($controllerSource, '$logger->resendEmailFromLog($request->get(\'id\')') !== false,
+            'retry controller no longer passes the requested ID to the resend lookup'
+        );
+        FsmtpTest::assert(strpos($resendSource, '$this->find($id)') !== false, 'retry path no longer delegates its ID to Logger::find');
+        FsmtpTest::assert(
+            strpos($findSource, '->where(\'id\',$id)') !== false,
+            'retry lookup no longer applies an exact ID predicate'
+        );
+
+        $table = FsmtpFactory::emailLogTable();
+        $targetId = FsmtpFactory::insertLog($table, ['subject' => 'retry scope target']);
+        $neighborId = FsmtpFactory::insertLog($table, ['subject' => 'retry scope neighbor']);
+
+        try {
+            $ids = $selectFixtureIds($table, function ($query) use ($targetId) {
+                $query->where('id', $targetId . ' scope-marker');
+            });
+
+            FsmtpTest::assertSame([$targetId], $ids, 'retry-shaped ID selection');
+            FsmtpTest::assert(!in_array($neighborId, $ids, true), 'retry-shaped selection included a neighboring log');
+        } finally {
+            FsmtpFactory::dropTable($table);
+        }
+    });
+
+    FsmtpTest::case('log delete selection remains scoped to integer-like requested IDs', function () use ($methodSource, $compactSource, $selectFixtureIds) {
+        $controllerSource = $compactSource($methodSource(LoggerController::class, 'delete'));
+        $deleteSource = $compactSource($methodSource(Logger::class, 'delete'));
+
+        FsmtpTest::assert(
+            strpos($controllerSource, '$id=(array)$request->get(\'id\')') !== false,
+            'delete controller no longer normalizes the requested IDs to an array'
+        );
+        FsmtpTest::assert(
+            strpos($deleteSource, '$ids=array_filter($id,\'intval\')') !== false,
+            'delete path no longer rejects IDs without an integer value'
+        );
+        FsmtpTest::assert(
+            strpos($deleteSource, '->whereIn(\'id\',$ids)') !== false,
+            'delete path no longer applies an ID-set predicate'
+        );
+
+        $table = FsmtpFactory::emailLogTable();
+        $targetId = FsmtpFactory::insertLog($table, ['subject' => 'delete scope target']);
+        $neighborId = FsmtpFactory::insertLog($table, ['subject' => 'delete scope neighbor']);
+        $requested = [$targetId . ' scope-marker', 'not-a-log-id', '0'];
+        $ids = array_filter($requested, 'intval');
+
+        try {
+            $selected = $selectFixtureIds($table, function ($query) use ($ids) {
+                $query->whereIn('id', $ids);
+            });
+
+            FsmtpTest::assertSame([$targetId], $selected, 'delete-shaped ID selection');
+            FsmtpTest::assert(!in_array($neighborId, $selected, true), 'delete-shaped selection included a neighboring log');
+        } finally {
+            FsmtpFactory::dropTable($table);
+        }
+    });
+};

--- a/tests/integration/input-validation.php
+++ b/tests/integration/input-validation.php
@@ -90,11 +90,19 @@ return function () {
             remove_filter('query', $observer, PHP_INT_MAX);
         }
 
-        FsmtpTest::assertAjaxHealthy($result, 'clamped day-time statistics');
         FsmtpTest::assertSame(1, count($queries), 'day-time statistics SELECT count');
         $query = isset($queries[0]) ? $queries[0] : '';
         FsmtpTest::assert(strpos($query, 'INTERVAL 365 DAY') !== false, 'day-time lookback was not clamped to 365');
         FsmtpTest::assert(strpos($query, '999999') === false, 'unclamped day-time lookback reached the SELECT');
+
+        $strictFailure = strpos($result['db_error'], 'ORDER BY clause is not in GROUP BY clause') !== false
+            && strpos($result['db_error'], 'only_full_group_by') !== false;
+        if (!FsmtpTest::knownFailure(
+            $strictFailure,
+            'heatmap ordering is rejected by ONLY_FULL_GROUP_BY after the lookback is clamped (app/Http/Controllers/DashboardController.php:60-62).'
+        )) {
+            FsmtpTest::assertAjaxHealthy($result, 'clamped day-time statistics');
+        }
     });
 
     FsmtpTest::case('sending statistics replace unlisted grouping columns with the daily whitelist fallback', function () {

--- a/tests/integration/mutation-roundtrips.php
+++ b/tests/integration/mutation-roundtrips.php
@@ -1,0 +1,408 @@
+<?php
+
+use FluentMail\App\Models\Settings;
+use FluentMail\App\Services\NotificationHelper;
+use FluentMail\Includes\Support\Arr;
+
+return function () {
+    /**
+     * Run option mutations in a real transaction, then restore both SQL and
+     * WordPress/FluentSMTP caches. Fingerprints keep real credentials out of
+     * failure output while proving the original option rows were restored.
+     */
+    $withOptionTransaction = function (callable $callback) {
+        global $wpdb;
+
+        $optionNames = [
+            'fluentmail-settings',
+            '_fluent_smtp_notify_settings',
+        ];
+        $fingerprints = function () use ($wpdb, $optionNames) {
+            $result = [];
+            foreach ($optionNames as $name) {
+                $row = $wpdb->get_row(
+                    $wpdb->prepare(
+                        "SELECT option_value, autoload FROM {$wpdb->options} WHERE option_name = %s",
+                        $name
+                    ),
+                    ARRAY_A
+                );
+                $result[$name] = $row
+                    ? hash('sha256', $row['option_value'] . '|' . $row['autoload'])
+                    : null;
+            }
+            return $result;
+        };
+
+        $beforeOptions = $fingerprints();
+        $beforeTables = FsmtpTest::protectedTableCounts();
+        $wpdb->query('START TRANSACTION');
+
+        try {
+            return $callback();
+        } finally {
+            $wpdb->query('ROLLBACK');
+            foreach ($optionNames as $name) {
+                wp_cache_delete($name, 'options');
+            }
+            wp_cache_delete('alloptions', 'options');
+            wp_cache_delete('notoptions', 'options');
+            fluentMailGetSettings([], false);
+
+            FsmtpTest::assertSame($beforeOptions, $fingerprints(), 'round-trip option restoration');
+            FsmtpTest::assertSame($beforeTables, FsmtpTest::protectedTableCounts(), 'round-trip protected tables');
+        }
+    };
+
+    $readSettings = function () {
+        $result = FsmtpTest::ajax('GET', '/settings');
+        FsmtpTest::assertAjaxHealthy($result, 'read FluentSMTP settings');
+        return Arr::get($result, 'data.data.settings', []);
+    };
+
+    $readNotificationSettings = function () {
+        $result = FsmtpTest::ajax('GET', 'settings/notification-settings');
+        FsmtpTest::assertAjaxHealthy($result, 'read notification settings');
+        return Arr::get($result, 'data.data.settings', []);
+    };
+
+    /** Assert one changed path and strict identity of the complete remainder. */
+    $assertOnlyFieldChanged = function ($before, $after, $path, $expected, $label) {
+        FsmtpTest::assertSame($expected, Arr::get($after, $path), $label . ' changed field');
+
+        $beforeRemainder = $before;
+        $afterRemainder = $after;
+        Arr::forget($beforeRemainder, $path);
+        Arr::forget($afterRemainder, $path);
+        FsmtpTest::assertSame(
+            $beforeRemainder,
+            $afterRemainder,
+            $label . ' every other field unchanged'
+        );
+    };
+
+    $baseMisc = function ($defaultConnection = '') {
+        return [
+            'log_emails'              => 'yes',
+            'log_saved_interval_days' => '14',
+            'disable_fluentcrm_logs'  => 'no',
+            'default_connection'      => $defaultConnection,
+            'fallback_connection'     => '',
+            'simulate_emails'         => 'yes',
+            'send_as_text'            => 'no',
+        ];
+    };
+
+    FsmtpTest::case('global settings round-trip preserves OAuth tokens during an unrelated misc save', function () use (
+        $withOptionTransaction,
+        $readSettings,
+        $assertOnlyFieldChanged,
+        $baseMisc
+    ) {
+        $withOptionTransaction(function () use ($readSettings, $assertOnlyFieldChanged, $baseMisc) {
+            $sender = 'outlook-roundtrip-' . FsmtpTest::uniq() . '@example.test';
+            $connectionKey = md5($sender);
+            $expireStamp = time() + 7200;
+            $initial = [
+                'connections' => [
+                    $connectionKey => [
+                        'title' => 'Suite Outlook',
+                        'provider_settings' => [
+                            'provider'           => 'outlook',
+                            'sender_name'        => 'Suite OAuth Sender',
+                            'sender_email'       => $sender,
+                            'force_from_name'    => 'no',
+                            'force_from_email'   => 'yes',
+                            'key_store'          => 'db',
+                            'client_id'          => 'suite-client-id',
+                            'client_secret'      => 'suite-client-secret',
+                            'access_token'       => 'suite-access-token',
+                            'refresh_token'      => 'suite-refresh-token',
+                            'expire_stamp'       => $expireStamp,
+                            'disable_encryption' => 'yes',
+                        ],
+                    ],
+                ],
+                'mappings' => [$sender => $connectionKey],
+                'misc'     => $baseMisc($connectionKey),
+                'suite_marker' => ['source' => 'global-roundtrip', 'version' => 1],
+            ];
+
+            $create = FsmtpTest::ajax('POST', '/settings/misc', $initial);
+            FsmtpTest::assertAjaxHealthy($create, 'create global settings');
+            $before = $readSettings();
+
+            FsmtpTest::assertSame(
+                'suite-access-token',
+                Arr::get($before, 'connections.' . $connectionKey . '.provider_settings.access_token'),
+                'created OAuth access token'
+            );
+            FsmtpTest::assertSame(
+                'suite-refresh-token',
+                Arr::get($before, 'connections.' . $connectionKey . '.provider_settings.refresh_token'),
+                'created OAuth refresh token'
+            );
+            FsmtpTest::assertSame(
+                $expireStamp,
+                Arr::get($before, 'connections.' . $connectionKey . '.provider_settings.expire_stamp'),
+                'created OAuth expiry'
+            );
+
+            $misc = $before['misc'];
+            $misc['log_saved_interval_days'] = '30';
+            $update = FsmtpTest::ajax('POST', '/misc-settings', ['settings' => $misc]);
+            FsmtpTest::assertAjaxHealthy($update, 'update one global misc field');
+            $after = $readSettings();
+
+            $assertOnlyFieldChanged(
+                $before,
+                $after,
+                'misc.log_saved_interval_days',
+                '30',
+                'unrelated global save'
+            );
+            FsmtpTest::assertSame(
+                'suite-access-token',
+                Arr::get($after, 'connections.' . $connectionKey . '.provider_settings.access_token'),
+                'OAuth access token after unrelated save'
+            );
+            FsmtpTest::assertSame(
+                'suite-refresh-token',
+                Arr::get($after, 'connections.' . $connectionKey . '.provider_settings.refresh_token'),
+                'OAuth refresh token after unrelated save'
+            );
+            FsmtpTest::assertSame(
+                $expireStamp,
+                Arr::get($after, 'connections.' . $connectionKey . '.provider_settings.expire_stamp'),
+                'OAuth expiry after unrelated save'
+            );
+
+            if (isset($after['connections'][$connectionKey])) {
+                $delete = FsmtpTest::ajax('POST', '/settings/delete', ['key' => $connectionKey]);
+                FsmtpTest::assertAjaxHealthy($delete, 'delete global round-trip connection');
+                $deleted = $readSettings();
+                FsmtpTest::assert(!isset($deleted['connections'][$connectionKey]), 'deleted connection still exists');
+                FsmtpTest::assert(!isset($deleted['mappings'][$sender]), 'deleted connection mapping still exists');
+            }
+        });
+    });
+
+    FsmtpTest::case('updateConnection changes one provider field and preserves the complete settings graph', function () use (
+        $withOptionTransaction,
+        $assertOnlyFieldChanged,
+        $baseMisc
+    ) {
+        $withOptionTransaction(function () use ($assertOnlyFieldChanged, $baseMisc) {
+            $sender = 'gmail-update-' . FsmtpTest::uniq() . '@example.test';
+            $connectionKey = md5($sender);
+            $initial = [
+                'connections' => [
+                    $connectionKey => [
+                        'title' => 'Suite Gmail',
+                        'provider_settings' => [
+                            'provider'           => 'gmail',
+                            'sender_name'        => 'Before Name',
+                            'sender_email'       => $sender,
+                            'force_from_name'    => 'no',
+                            'force_from_email'   => 'yes',
+                            'key_store'          => 'db',
+                            'client_id'          => 'suite-client-id',
+                            'client_secret'      => 'suite-client-secret',
+                            'access_token'       => 'suite-access-token',
+                            'refresh_token'      => 'suite-refresh-token',
+                            'expire_stamp'       => time() + 3600,
+                            'disable_encryption' => 'yes',
+                        ],
+                    ],
+                ],
+                'mappings' => [$sender => $connectionKey],
+                'misc'     => $baseMisc($connectionKey),
+                'suite_marker' => ['source' => 'update-connection', 'version' => 1],
+            ];
+
+            $model = new Settings();
+            $model->saveGlobalSettings($initial);
+            $before = $model->getSettings();
+            $updatedConnection = $before['connections'][$connectionKey]['provider_settings'];
+            $updatedConnection['sender_name'] = 'After Name';
+
+            $model->updateConnection($sender, $updatedConnection);
+            $after = $model->getSettings();
+            $assertOnlyFieldChanged(
+                $before,
+                $after,
+                'connections.' . $connectionKey . '.provider_settings.sender_name',
+                'After Name',
+                'updateConnection'
+            );
+
+            $model->delete($connectionKey);
+            $deleted = $model->getSettings();
+            FsmtpTest::assert(!isset($deleted['connections'][$connectionKey]), 'updateConnection fixture was not deleted');
+            FsmtpTest::assert(!isset($deleted['mappings'][$sender]), 'updateConnection fixture mapping was not deleted');
+        });
+    });
+
+    FsmtpTest::case('sender alias round-trip adds and removes one mapping without changing connection data', function () use (
+        $withOptionTransaction,
+        $readSettings,
+        $baseMisc
+    ) {
+        FsmtpTest::interceptHttp(function ($url) {
+            if (strpos($url, 'https://api.tosend.com/v2/info?') === 0) {
+                return [
+                    'headers'  => [],
+                    'body'     => wp_json_encode([
+                        'account' => ['status' => 'active'],
+                        'domains' => [[
+                            'domain_name'        => 'example.test',
+                            'verification_status' => 'verified',
+                        ]],
+                    ]),
+                    'response' => ['code' => 200, 'message' => 'OK'],
+                    'cookies'  => [],
+                    'filename' => null,
+                ];
+            }
+            return null;
+        });
+
+        try {
+            $withOptionTransaction(function () use ($readSettings, $baseMisc) {
+                $sender = 'tosend-primary-' . FsmtpTest::uniq() . '@example.test';
+                $alias = 'tosend-alias-' . FsmtpTest::uniq() . '@example.test';
+                $connectionKey = md5($sender);
+                $initial = [
+                    'connections' => [
+                        $connectionKey => [
+                            'title' => 'Suite toSend',
+                            'provider_settings' => [
+                                'provider'           => 'tosend',
+                                'sender_name'        => 'Suite toSend Sender',
+                                'sender_email'       => $sender,
+                                'force_from_name'    => 'no',
+                                'force_from_email'   => 'yes',
+                                'key_store'          => 'db',
+                                'api_key'            => 'suite-api-key',
+                                'additional_senders' => [],
+                                'disable_encryption' => 'yes',
+                            ],
+                        ],
+                    ],
+                    'mappings' => [$sender => $connectionKey],
+                    'misc'     => $baseMisc($connectionKey),
+                    'suite_marker' => ['source' => 'sender-alias', 'version' => 1],
+                ];
+
+                $create = FsmtpTest::ajax('POST', '/settings/misc', $initial);
+                FsmtpTest::assertAjaxHealthy($create, 'create sender alias connection');
+                $before = $readSettings();
+
+                $add = FsmtpTest::ajax('POST', 'settings/add_new_sender_email', [
+                    'connection_id' => $connectionKey,
+                    'new_sender'    => $alias,
+                ]);
+                FsmtpTest::assertAjaxHealthy($add, 'add sender alias');
+                fluentMailGetSettings([], false);
+                $afterAdd = $readSettings();
+
+                FsmtpTest::assertSame(
+                    $connectionKey,
+                    isset($afterAdd['mappings'][$alias]) ? $afterAdd['mappings'][$alias] : null,
+                    'added sender mapping'
+                );
+                $withoutAlias = $afterAdd;
+                unset($withoutAlias['mappings'][$alias]);
+                FsmtpTest::assertSame($before, $withoutAlias, 'sender add every other field unchanged');
+
+                $remove = FsmtpTest::ajax('POST', 'settings/remove_sender_email', [
+                    'connection_id' => $connectionKey,
+                    'email'         => $alias,
+                ]);
+                FsmtpTest::assertAjaxHealthy($remove, 'remove sender alias');
+                fluentMailGetSettings([], false);
+                $afterRemove = $readSettings();
+                FsmtpTest::assertSame($before, $afterRemove, 'sender remove restored the exact settings graph');
+
+                $delete = FsmtpTest::ajax('POST', '/settings/delete', ['key' => $connectionKey]);
+                FsmtpTest::assertAjaxHealthy($delete, 'delete sender alias connection');
+                $deleted = $readSettings();
+                FsmtpTest::assert(!isset($deleted['connections'][$connectionKey]), 'sender alias connection was not deleted');
+            });
+
+            $requests = FsmtpTest::httpRequests();
+            FsmtpTest::assertSame(1, count($requests), 'toSend account-info request count');
+            $requestUrl = isset($requests[0]['url']) ? $requests[0]['url'] : '';
+            FsmtpTest::assertSame(
+                'https://api.tosend.com/v2/info',
+                strtok($requestUrl, '?'),
+                'toSend account-info endpoint'
+            );
+        } finally {
+            FsmtpTest::interceptHttp();
+        }
+    });
+
+    FsmtpTest::case('notification settings update one summary field without losing channel configuration', function () use (
+        $withOptionTransaction,
+        $readNotificationSettings,
+        $assertOnlyFieldChanged
+    ) {
+        $withOptionTransaction(function () use ($readNotificationSettings, $assertOnlyFieldChanged) {
+            delete_option('_fluent_smtp_notify_settings');
+            wp_cache_delete('_fluent_smtp_notify_settings', 'options');
+
+            $create = FsmtpTest::ajax('POST', 'settings/notification-settings', [
+                'settings' => [
+                    'enabled'      => 'yes',
+                    'notify_email' => 'summary-before@example.test',
+                    'notify_days'  => ['Mon', 'Wed', 'Fri'],
+                ],
+            ]);
+            FsmtpTest::assertAjaxHealthy($create, 'create notification summary settings');
+
+            NotificationHelper::updateChannelSettings('slack', [
+                'status'      => 'yes',
+                'token'       => 'suite-slack-token',
+                'webhook_url' => 'https://hooks.example.test/suite',
+            ]);
+            $before = $readNotificationSettings();
+
+            $update = FsmtpTest::ajax('POST', 'settings/notification-settings', [
+                'settings' => [
+                    'enabled'      => $before['enabled'],
+                    'notify_email' => 'summary-after@example.test',
+                    'notify_days'  => $before['notify_days'],
+                ],
+            ]);
+            FsmtpTest::assertAjaxHealthy($update, 'update one notification summary field');
+            $after = $readNotificationSettings();
+
+            $assertOnlyFieldChanged(
+                $before,
+                $after,
+                'notify_email',
+                'summary-after@example.test',
+                'notification settings'
+            );
+            FsmtpTest::assertSame('suite-slack-token', Arr::get($after, 'slack.token'), 'Slack token after summary save');
+            FsmtpTest::assertSame(
+                'https://hooks.example.test/suite',
+                Arr::get($after, 'slack.webhook_url'),
+                'Slack webhook after summary save'
+            );
+            FsmtpTest::assert(
+                in_array('slack', (array)Arr::get($after, 'active_channel', []), true),
+                'Slack active channel was lost'
+            );
+
+            delete_option('_fluent_smtp_notify_settings');
+            wp_cache_delete('_fluent_smtp_notify_settings', 'options');
+            FsmtpTest::assertSame(
+                null,
+                get_option('_fluent_smtp_notify_settings', null),
+                'notification fixture delete'
+            );
+        });
+    });
+};

--- a/tests/integration/pure-functions.php
+++ b/tests/integration/pure-functions.php
@@ -1,0 +1,108 @@
+<?php
+
+use FluentMail\App\Http\Controllers\SettingsController;
+use FluentMail\App\Services\ConnectionHealth;
+use FluentMail\App\Services\Reporting;
+use FluentMail\Includes\Support\ValidationException;
+
+return function () {
+    /** Invoke a non-public deterministic helper without copying its logic. */
+    $invoke = function ($target, $method, array $arguments = []) {
+        $reflection = new ReflectionMethod($target, $method);
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs(is_object($target) ? $target : null, $arguments);
+    };
+
+    $withoutConstructor = function ($class) {
+        return (new ReflectionClass($class))->newInstanceWithoutConstructor();
+    };
+
+    FsmtpTest::case('reporting frequency changes at the daily weekly and monthly boundaries', function () use ($invoke) {
+        $reporting = new Reporting();
+        $from = new DateTime('2026-01-01 00:00:00', new DateTimeZone('UTC'));
+        $frequencyFor = function ($days) use ($invoke, $reporting, $from) {
+            $to = clone $from;
+            $to->modify('+' . $days . ' days');
+            return $invoke($reporting, 'getFrequency', [$from, $to]);
+        };
+
+        FsmtpTest::assertSame('P1D', $frequencyFor(62), '62-day reporting frequency');
+        FsmtpTest::assertSame('P1W', $frequencyFor(63), '63-day reporting frequency');
+        FsmtpTest::assertSame('P1W', $frequencyFor(181), '181-day reporting frequency');
+        FsmtpTest::assertSame('P1M', $frequencyFor(182), '182-day reporting frequency');
+    });
+
+    FsmtpTest::case('reporting basic formatter normalizes strings and date objects to ISO dates', function () use ($invoke) {
+        $reporting = new Reporting();
+
+        FsmtpTest::assertSame(
+            '2026-08-04',
+            $invoke($reporting, 'basicFormatter', ['2026-08-04 19:45:00']),
+            'basic formatter string input'
+        );
+        FsmtpTest::assertSame(
+            '2026-08-04',
+            $invoke($reporting, 'basicFormatter', [new DateTime('2026-08-04 01:15:00', new DateTimeZone('UTC'))]),
+            'basic formatter DateTime input'
+        );
+    });
+
+    FsmtpTest::case('reporting month formatter produces a stable abbreviated month and year', function () use ($invoke) {
+        $reporting = new Reporting();
+
+        FsmtpTest::assertSame(
+            'Aug 2026',
+            $invoke($reporting, 'monYearFormatter', ['2026-08-04']),
+            'month-year formatter string input'
+        );
+        FsmtpTest::assertSame(
+            'Jan 2027',
+            $invoke($reporting, 'monYearFormatter', [new DateTime('2027-01-31', new DateTimeZone('UTC'))]),
+            'month-year formatter DateTime input'
+        );
+    });
+
+    FsmtpTest::case('test-send duration uses milliseconds below one second and seconds at the boundary', function () use (
+        $invoke,
+        $withoutConstructor
+    ) {
+        $controller = $withoutConstructor(SettingsController::class);
+
+        FsmtpTest::assertSame(
+            sprintf(__('Delivered in %s milliseconds', 'fluent-smtp'), number_format_i18n(125)),
+            $invoke($controller, 'formatDuration', [0.125]),
+            'sub-second duration'
+        );
+        FsmtpTest::assertSame(
+            sprintf(__('Delivered in %s seconds', 'fluent-smtp'), number_format_i18n(1, 2)),
+            $invoke($controller, 'formatDuration', [1.0]),
+            'one-second duration'
+        );
+    });
+
+    FsmtpTest::case('connection health preserves the message from an ordinary exception', function () use ($invoke) {
+        $message = 'provider unavailable ' . FsmtpTest::uniq();
+
+        FsmtpTest::assertSame(
+            $message,
+            $invoke(new ConnectionHealth(), 'flattenMessage', [new Exception($message)]),
+            'ordinary health exception message'
+        );
+    });
+
+    FsmtpTest::case('connection health flattens every validation error in field order', function () use ($invoke) {
+        $exception = new ValidationException('Unprocessable Entity', 422, null, [
+            'sender_email' => [
+                'Sender is required.',
+                ['Sender must be valid.', 'Use a mailbox address.'],
+            ],
+            'api_key' => 'API key is missing.',
+        ]);
+
+        FsmtpTest::assertSame(
+            'Sender is required. Sender must be valid. Use a mailbox address. API key is missing.',
+            $invoke(new ConnectionHealth(), 'flattenMessage', [$exception]),
+            'flattened health validation message'
+        );
+    });
+};

--- a/tests/integration/throughput-guards.php
+++ b/tests/integration/throughput-guards.php
@@ -1,0 +1,107 @@
+<?php
+
+use FluentMail\App\Models\Logger;
+
+return function () {
+    FsmtpTest::case('log pruning uses fixed batches with query counts proportional to two fixture sizes', function () {
+        global $wpdb;
+        $batchSize = 3;
+        $scenarios = [
+            ['rows' => 2, 'queries' => 1],
+            ['rows' => 8, 'queries' => 3],
+        ];
+
+        foreach ($scenarios as $scenario) {
+            $table = FsmtpFactory::emailLogTable(false, true);
+            $cutoff = current_datetime()->sub(new DateInterval('P14D'));
+            for ($index = 0; $index < $scenario['rows']; $index++) {
+                FsmtpFactory::insertLog($table, [
+                    'created_at' => $cutoff->modify('-1 day -' . $index . ' minutes')->format('Y-m-d H:i:s'),
+                ]);
+            }
+
+            $queries = [];
+            $observer = function ($query) use (&$queries, $table) {
+                if (stripos(ltrim($query), 'DELETE FROM') === 0 && strpos($query, $table) !== false) {
+                    $queries[] = $query;
+                }
+                return $query;
+            };
+            $batchFilter = function () use ($batchSize) {
+                return $batchSize;
+            };
+
+            add_filter('query', $observer, PHP_INT_MAX);
+            add_filter('fluentmail_log_delete_batch_size', $batchFilter, PHP_INT_MAX);
+            try {
+                $deleted = FsmtpFactory::loggerForTable($table)->deleteLogsOlderThan(14);
+
+                FsmtpTest::assertSame($scenario['rows'], $deleted, $scenario['rows'] . '-row deleted count');
+                FsmtpTest::assertSame($scenario['queries'], count($queries), $scenario['rows'] . '-row DELETE query count');
+                FsmtpTest::assertSame(0, (int)$wpdb->get_var("SELECT COUNT(*) FROM `{$table}`"), $scenario['rows'] . '-row table remainder');
+                foreach ($queries as $query) {
+                    FsmtpTest::assert(
+                        preg_match('/\sLIMIT\s+' . $batchSize . '\s*$/i', $query) === 1,
+                        $scenario['rows'] . '-row DELETE did not keep the fixed batch size'
+                    );
+                }
+            } finally {
+                remove_filter('query', $observer, PHP_INT_MAX);
+                remove_filter('fluentmail_log_delete_batch_size', $batchFilter, PHP_INT_MAX);
+                FsmtpFactory::dropTable($table);
+            }
+        }
+    });
+
+    FsmtpTest::case('log pagination keeps a two-query budget and fixed page size at two table sizes', function () {
+        $scenarios = [
+            ['rows' => 4, 'page_rows' => 4],
+            ['rows' => 40, 'page_rows' => 10],
+        ];
+
+        foreach ($scenarios as $scenario) {
+            $table = FsmtpFactory::emailLogTable(false, true);
+            for ($index = 0; $index < $scenario['rows']; $index++) {
+                FsmtpFactory::insertLog($table, [
+                    'subject' => 'throughput-' . $scenario['rows'] . '-' . $index,
+                ]);
+            }
+
+            $redirect = FsmtpFactory::productionLogTableRedirect($table);
+            $queries = [];
+            $observer = function ($query) use (&$queries, $table) {
+                if (stripos(ltrim($query), 'SELECT') === 0 && strpos($query, $table) !== false) {
+                    $queries[] = $query;
+                }
+                return $query;
+            };
+            $oldGet = $_GET;
+            $oldRequest = $_REQUEST;
+            $_GET = ['page' => 1];
+            $_REQUEST = ['per_page' => 10, 'page' => 1];
+
+            add_filter('query', $redirect, PHP_INT_MAX - 1);
+            add_filter('query', $observer, PHP_INT_MAX);
+            try {
+                $result = (new Logger())->get([
+                    'page' => 1,
+                    'per_page' => 10,
+                    'status' => '',
+                    'date_range' => [],
+                    'search' => '',
+                ]);
+
+                FsmtpTest::assertSame(2, count($queries), $scenario['rows'] . '-row pagination query count');
+                FsmtpTest::assertSame($scenario['rows'], $result['total'], $scenario['rows'] . '-row pagination total');
+                FsmtpTest::assertSame($scenario['page_rows'], count($result['data']), $scenario['rows'] . '-row first-page batch size');
+                FsmtpTest::assertSame(10, $result['per_page'], $scenario['rows'] . '-row pagination per-page value');
+            } finally {
+                remove_filter('query', $redirect, PHP_INT_MAX - 1);
+                remove_filter('query', $observer, PHP_INT_MAX);
+                $_GET = $oldGet;
+                $_REQUEST = $oldRequest;
+                FsmtpFactory::dropTable($table);
+            }
+        }
+    });
+};

--- a/tests/integration/unauthenticated-surface.php
+++ b/tests/integration/unauthenticated-surface.php
@@ -1,0 +1,227 @@
+<?php
+
+return function () {
+    $protectedOptions = [
+        'fluentmail-settings',
+        '_fluentsmtp_intended_outlook_info',
+        '_fluentmail_last_generated_state',
+    ];
+
+    /** Hash exact option rows so failures never print settings or OAuth data. */
+    $optionFingerprints = function () use ($protectedOptions) {
+        global $wpdb;
+        $fingerprints = [];
+        foreach ($protectedOptions as $name) {
+            $row = $wpdb->get_row(
+                $wpdb->prepare(
+                    "SELECT option_value, autoload FROM {$wpdb->options} WHERE option_name = %s",
+                    $name
+                ),
+                ARRAY_A
+            );
+            $fingerprints[$name] = $row
+                ? hash('sha256', $row['option_value'] . '|' . $row['autoload'])
+                : null;
+        }
+        return $fingerprints;
+    };
+
+    $clearOptionCaches = function () use ($protectedOptions) {
+        foreach ($protectedOptions as $name) {
+            wp_cache_delete($name, 'options');
+        }
+        wp_cache_delete('alloptions', 'options');
+        wp_cache_delete('notoptions', 'options');
+    };
+
+    /** Supply one guarded state inside a rolled-back transaction. */
+    $withProtectedState = function (callable $callback) use ($optionFingerprints, $clearOptionCaches) {
+        global $wpdb;
+        $original = $optionFingerprints();
+        $state = FsmtpTest::uniq('outlook-state');
+        $wpdb->query('START TRANSACTION');
+        update_option('_fluentmail_last_generated_state', $state, false);
+        $clearOptionCaches();
+        $guarded = $optionFingerprints();
+
+        try {
+            FsmtpTest::interceptHttp();
+            $callback($state);
+            FsmtpTest::assertSame($guarded, $optionFingerprints(), 'OAuth protected-option fingerprints');
+            FsmtpTest::assertSame(0, count(FsmtpTest::httpRequests()), 'OAuth callback outbound HTTP count');
+        } finally {
+            $wpdb->query('ROLLBACK');
+            $clearOptionCaches();
+            FsmtpTest::assertSame($original, $optionFingerprints(), 'OAuth option rollback fingerprints');
+        }
+    };
+
+    /** Return the runtime-registered GET endpoint, never a copied callback. */
+    $outlookEndpoint = function () {
+        static $endpoint;
+        if ($endpoint !== null) {
+            return $endpoint;
+        }
+
+        if (!did_action('rest_api_init')) {
+            do_action('rest_api_init', rest_get_server());
+        }
+        $routes = rest_get_server()->get_routes();
+        $registered = isset($routes['/fluent-smtp/outlook_callback'])
+            ? $routes['/fluent-smtp/outlook_callback']
+            : [];
+
+        foreach ($registered as $candidate) {
+            if (!is_array($candidate) || empty($candidate['methods']['GET'])) {
+                continue;
+            }
+            if (!empty($candidate['callback']) && !empty($candidate['permission_callback'])) {
+                $endpoint = $candidate;
+                return $endpoint;
+            }
+        }
+
+        throw new RuntimeException('The Outlook callback GET route is not registered at runtime.');
+    };
+
+    /** Dispatch the registered REST route with the globals a real GET supplies. */
+    $dispatchRest = function (array $params) {
+        $request = new WP_REST_Request('GET', '/fluent-smtp/outlook_callback');
+        $request->set_query_params($params);
+        $oldRequest = $_REQUEST;
+        $_REQUEST = $params;
+        $handlerProvider = function () {
+            return function () {
+                throw new FsmtpAjaxExit('Rejected REST probe reached the callback.');
+            };
+        };
+        $handlerFilters = [
+            'wp_die_handler',
+            'wp_die_ajax_handler',
+            'wp_die_json_handler',
+            'wp_die_jsonp_handler',
+        ];
+        foreach ($handlerFilters as $filter) {
+            add_filter($filter, $handlerProvider, PHP_INT_MAX);
+        }
+        try {
+            return rest_get_server()->dispatch($request);
+        } catch (FsmtpAjaxExit $e) {
+            return new WP_REST_Response(['code' => 'fsmtp_test_callback_reached'], 200);
+        } finally {
+            foreach ($handlerFilters as $filter) {
+                remove_filter($filter, $handlerProvider, PHP_INT_MAX);
+            }
+            $_REQUEST = $oldRequest;
+        }
+    };
+
+    FsmtpTest::case('Outlook callback is a runtime-registered guarded GET route', function () use ($outlookEndpoint) {
+        $endpoint = $outlookEndpoint();
+        FsmtpTest::assertSame(
+            'FluentMail\\App\\Hooks\\Handlers\\ActionsRegistrar::handleOutlookCallback',
+            get_class($endpoint['callback'][0]) . '::' . $endpoint['callback'][1],
+            'Outlook REST callback'
+        );
+        FsmtpTest::assertSame(
+            'FluentMail\\App\\Hooks\\Handlers\\ActionsRegistrar::verifyOutlookCallbackState',
+            get_class($endpoint['permission_callback'][0]) . '::' . $endpoint['permission_callback'][1],
+            'Outlook REST permission callback'
+        );
+    });
+
+    FsmtpTest::case('Outlook callback rejects an absent state without changing OAuth data', function () use (
+        $withProtectedState,
+        $dispatchRest
+    ) {
+        $withProtectedState(function () use ($dispatchRest) {
+            wp_set_current_user(0);
+            $response = $dispatchRest(['code' => 'suite-code-without-state']);
+            FsmtpTest::assert(in_array($response->get_status(), [401, 403], true), 'absent-state REST status was not denied');
+            $data = $response->get_data();
+            FsmtpTest::assertSame('rest_forbidden', isset($data['code']) ? $data['code'] : null, 'absent-state REST error code');
+        });
+    });
+
+    FsmtpTest::case('Outlook callback rejects a mismatched state without changing OAuth data', function () use (
+        $withProtectedState,
+        $dispatchRest
+    ) {
+        $withProtectedState(function ($state) use ($dispatchRest) {
+            wp_set_current_user(0);
+            $response = $dispatchRest([
+                'state' => $state . '-wrong',
+                'code'  => 'suite-code-with-wrong-state',
+            ]);
+            FsmtpTest::assert(in_array($response->get_status(), [401, 403], true), 'mismatched-state REST status was not denied');
+            $data = $response->get_data();
+            FsmtpTest::assertSame('rest_forbidden', isset($data['code']) ? $data['code'] : null, 'mismatched-state REST error code');
+        });
+    });
+
+    FsmtpTest::case('Outlook callback with a wrong code stores no connection or token', function () use (
+        $withProtectedState,
+        $outlookEndpoint
+    ) {
+        $withProtectedState(function ($state) use ($outlookEndpoint) {
+            wp_set_current_user(0);
+            $endpoint = $outlookEndpoint();
+            $params = [
+                'state' => $state,
+                'code'  => 'suite-invalid-authorization-code',
+            ];
+            $request = new WP_REST_Request('GET', '/fluent-smtp/outlook_callback');
+            $request->set_query_params($params);
+            $oldRequest = $_REQUEST;
+            $_REQUEST = $params;
+
+            FsmtpTest::assertSame(true, (bool)call_user_func($endpoint['permission_callback'], $request), 'matching-state permission result');
+
+            $died = false;
+            $body = '';
+            $handlerProvider = function () use (&$died, &$body) {
+                return function ($message = '', $title = '', $args = []) use (&$died, &$body) {
+                    $died = true;
+                    $body = is_scalar($message) ? (string)$message : '';
+                    throw new FsmtpAjaxExit('REST callback completed through wp_die.');
+                };
+            };
+            $handlerFilters = [
+                'wp_die_handler',
+                'wp_die_ajax_handler',
+                'wp_die_json_handler',
+                'wp_die_jsonp_handler',
+            ];
+            foreach ($handlerFilters as $filter) {
+                add_filter($filter, $handlerProvider, PHP_INT_MAX);
+            }
+
+            try {
+                call_user_func($endpoint['callback'], $request);
+            } catch (FsmtpAjaxExit $e) {
+                // Expected: the endpoint only renders the supplied code.
+            } finally {
+                foreach ($handlerFilters as $filter) {
+                    remove_filter($filter, $handlerProvider, PHP_INT_MAX);
+                }
+                $_REQUEST = $oldRequest;
+            }
+
+            FsmtpTest::assert($died, 'matching-state callback did not complete through wp_die');
+        });
+    });
+
+    FsmtpTest::case('router runtime inventory contains no anonymous AJAX actions', function () use ($optionFingerprints) {
+        global $wp_filter;
+        wp_set_current_user(0);
+        $before = $optionFingerprints();
+        $prefix = 'wp_ajax_nopriv_' . FLUENTMAIL . '-';
+        $hooks = array_values(array_filter(array_keys($wp_filter), function ($hook) use ($prefix) {
+            return strpos($hook, $prefix) === 0;
+        }));
+        sort($hooks);
+
+        FsmtpTest::assertSame([], $hooks, 'runtime wp_ajax_nopriv router inventory');
+        FsmtpTest::assertSame($before, $optionFingerprints(), 'anonymous AJAX inventory option fingerprints');
+    });
+};

--- a/tests/js/request-layer.test.js
+++ b/tests/js/request-layer.test.js
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('vue', () => ({
+    default: {
+        use: vi.fn(),
+        mixin: vi.fn(),
+        filter: vi.fn(),
+        prototype: {}
+    }
+}));
+
+vi.mock('vue-router', () => ({ default: function Router() {} }));
+vi.mock('element-ui/lib/locale/lang/en', () => ({ default: {} }));
+vi.mock('element-ui/lib/locale', () => ({ default: { use: vi.fn() } }));
+vi.mock('element-ui', () => {
+    const plugin = {};
+    return {
+        Tag: plugin,
+        Row: plugin,
+        Col: plugin,
+        Menu: plugin,
+        Form: plugin,
+        Alert: plugin,
+        Table: plugin,
+        Input: plugin,
+        Option: plugin,
+        Radio: plugin,
+        Button: plugin,
+        Select: plugin,
+        Dialog: plugin,
+        Popover: plugin,
+        Loading: { directive: plugin },
+        Tooltip: plugin,
+        MenuItem: plugin,
+        Checkbox: plugin,
+        FormItem: plugin,
+        Pagination: plugin,
+        DatePicker: plugin,
+        TimePicker: plugin,
+        RadioGroup: plugin,
+        MessageBox: { alert: vi.fn(), confirm: vi.fn() },
+        OptionGroup: plugin,
+        ButtonGroup: plugin,
+        TableColumn: plugin,
+        Notification: vi.fn(),
+        CheckboxGroup: plugin,
+        RadioButton: plugin,
+        Switch: plugin,
+        Collapse: plugin,
+        CollapseItem: plugin,
+        Skeleton: plugin,
+        SkeletonItem: plugin
+    };
+});
+
+import FluentMail from '../../resources/admin/Bits/FluentMail';
+
+describe('FluentMail admin request layer', () => {
+    let fluentMail;
+
+    beforeEach(() => {
+        global.window = {
+            ajaxurl: '/wp-admin/admin-ajax.php',
+            FluentMailAdmin: {
+                slug: 'fluentmail',
+                nonce: 'suite-nonce'
+            },
+            jQuery: {
+                get: vi.fn(() => 'get-result'),
+                post: vi.fn(() => 'post-result')
+            }
+        };
+
+        fluentMail = Object.create(FluentMail.prototype);
+        fluentMail.appVars = window.FluentMailAdmin;
+        window.FluentMail = fluentMail;
+    });
+
+    it('forwards the selected jQuery method to the WordPress AJAX URL', () => {
+        const options = { action: 'suite-action', page: 2 };
+
+        const result = fluentMail.request('get', options);
+
+        expect(result).toBe('get-result');
+        expect(window.jQuery.get).toHaveBeenCalledOnce();
+        expect(window.jQuery.get).toHaveBeenCalledWith(window.ajaxurl, options);
+        expect(window.jQuery.post).not.toHaveBeenCalled();
+    });
+
+    it('adds the GET action and nonce while preserving caller parameters', () => {
+        const options = { page: 3, search: 'delivery report' };
+
+        const result = fluentMail.$get('logs', options);
+
+        expect(result).toBe('get-result');
+        expect(window.jQuery.get).toHaveBeenCalledWith('/wp-admin/admin-ajax.php', {
+            page: 3,
+            search: 'delivery report',
+            action: 'fluentmail-get-logs',
+            nonce: 'suite-nonce'
+        });
+    });
+
+    it('adds the POST action and nonce while preserving caller payloads', () => {
+        const options = {
+            id: [17, 23],
+            settings: { log_emails: 'yes' }
+        };
+
+        const result = fluentMail.$post('logs/delete', options);
+
+        expect(result).toBe('post-result');
+        expect(window.jQuery.post).toHaveBeenCalledWith('/wp-admin/admin-ajax.php', {
+            id: [17, 23],
+            settings: { log_emails: 'yes' },
+            action: 'fluentmail-post-logs/delete',
+            nonce: 'suite-nonce'
+        });
+    });
+});

--- a/tests/lib/factory.php
+++ b/tests/lib/factory.php
@@ -90,6 +90,22 @@ class FsmtpFactory
         return $logger;
     }
 
+    /**
+     * Redirect production log-table SQL to an isolated real table. This keeps
+     * hard-coded reporting/controller paths database-backed without allowing a
+     * behavioral test to read, insert, update, or delete a production log row.
+     */
+    public static function productionLogTableRedirect($table)
+    {
+        global $wpdb;
+        self::assertIdentifier($table);
+        $productionTable = $wpdb->prefix . FLUENT_MAIL_DB_PREFIX . 'email_logs';
+
+        return function ($query) use ($productionTable, $table) {
+            return str_replace($productionTable, $table, $query);
+        };
+    }
+
     /** @return array<string,array<int,string>> index name => ordered columns */
     public static function indexes($table)
     {

--- a/tests/lib/factory.php
+++ b/tests/lib/factory.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Exact, database-backed fixtures for FluentSMTP integration tests.
+ *
+ * The production log table is never used for behavioral assertions. Tests get
+ * isolated InnoDB tables and point a real Logger model at them via reflection.
+ */
+
+class FsmtpFactory
+{
+    /** @var array<int,string> */
+    private static $tables = [];
+
+    /** Create the minimum shipped 2.3.0 email-log table shape. */
+    public static function emailLogTable($statusIndex = true, $compositeIndex = false)
+    {
+        global $wpdb;
+
+        $suffix = strtolower(wp_generate_password(10, false, false));
+        $table = $wpdb->prefix . 'fsmtp_test_' . preg_replace('/[^a-z0-9_]/', '', $suffix);
+        self::assertIdentifier($table);
+
+        $indexes = [];
+        if ($statusIndex) {
+            $indexes[] = 'INDEX `status` (`status`)';
+        }
+        if ($compositeIndex) {
+            $indexes[] = 'INDEX `created_at_status` (`created_at`, `status`)';
+        }
+        $indexSql = $indexes ? ",\n            " . implode(",\n            ", $indexes) : '';
+
+        $sql = "CREATE TABLE `{$table}` (
+            `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `site_id` INT UNSIGNED NULL,
+            `to` VARCHAR(255) NULL,
+            `from` VARCHAR(255) NULL,
+            `subject` VARCHAR(255) NULL,
+            `body` LONGTEXT NULL,
+            `headers` LONGTEXT NULL,
+            `attachments` LONGTEXT NULL,
+            `status` VARCHAR(20) DEFAULT 'pending',
+            `response` TEXT NULL,
+            `extra` TEXT NULL,
+            `retries` INT UNSIGNED NULL DEFAULT 0,
+            `resent_count` INT UNSIGNED NULL DEFAULT 0,
+            `source` VARCHAR(255) NULL,
+            `created_at` TIMESTAMP NULL,
+            `updated_at` TIMESTAMP NULL,
+            PRIMARY KEY (`id`){$indexSql}
+        ) ENGINE=InnoDB";
+
+        $result = $wpdb->query($sql);
+        if ($result === false) {
+            throw new RuntimeException('Could not create test log table: ' . $wpdb->last_error);
+        }
+
+        self::$tables[] = $table;
+        return $table;
+    }
+
+    /** Insert one row and return its exact ID. */
+    public static function insertLog($table, array $values)
+    {
+        global $wpdb;
+        self::assertIdentifier($table);
+
+        $defaults = [
+            'to'         => 'recipient@example.test',
+            'from'       => 'sender@example.test',
+            'subject'    => FsmtpTest::uniq('fixture'),
+            'status'     => 'sent',
+            'created_at' => current_time('mysql', true),
+            'updated_at' => current_time('mysql', true),
+        ];
+
+        if ($wpdb->insert($table, array_merge($defaults, $values)) === false) {
+            throw new RuntimeException('Could not insert test log: ' . $wpdb->last_error);
+        }
+        return (int) $wpdb->insert_id;
+    }
+
+    /** Point a real Logger instance at an isolated test table. */
+    public static function loggerForTable($table)
+    {
+        self::assertIdentifier($table);
+        $logger = new \FluentMail\App\Models\Logger();
+        $property = new ReflectionProperty($logger, 'table');
+        $property->setAccessible(true);
+        $property->setValue($logger, $table);
+        return $logger;
+    }
+
+    /** @return array<string,array<int,string>> index name => ordered columns */
+    public static function indexes($table)
+    {
+        global $wpdb;
+        self::assertIdentifier($table);
+
+        $rows = $wpdb->get_results("SHOW INDEX FROM `{$table}`", ARRAY_A);
+        $indexes = [];
+        foreach ($rows as $row) {
+            $indexes[$row['Key_name']][(int) $row['Seq_in_index']] = $row['Column_name'];
+        }
+        foreach ($indexes as &$columns) {
+            ksort($columns);
+            $columns = array_values($columns);
+        }
+        unset($columns);
+        return $indexes;
+    }
+
+    public static function dropTable($table)
+    {
+        global $wpdb;
+        self::assertIdentifier($table);
+        $wpdb->query("DROP TABLE IF EXISTS `{$table}`");
+        self::$tables = array_values(array_filter(self::$tables, function ($candidate) use ($table) {
+            return $candidate !== $table;
+        }));
+    }
+
+    /** Exact cleanup; safe and intentionally idempotent. */
+    public static function cleanup()
+    {
+        foreach (array_reverse(self::$tables) as $table) {
+            self::dropTable($table);
+        }
+        self::$tables = [];
+    }
+
+    private static function assertIdentifier($identifier)
+    {
+        if (!is_string($identifier) || !preg_match('/^[A-Za-z0-9_]+$/', $identifier)) {
+            throw new InvalidArgumentException('Unsafe test-table identifier.');
+        }
+    }
+}

--- a/tests/lib/harness.php
+++ b/tests/lib/harness.php
@@ -61,6 +61,12 @@ class FsmtpTest
     /** @var bool */
     private static $routesLoaded = false;
 
+    /** @var string */
+    private static $coverageFile = '';
+
+    /** @var bool */
+    private static $coverageStarted = false;
+
     /** @return array<string,mixed> */
     public static function config()
     {
@@ -77,6 +83,7 @@ class FsmtpTest
      */
     public static function boot()
     {
+        self::startCoverage();
         self::$startedAt = microtime(true);
 
         $hint = self::config()['plugin_dir_hint'];
@@ -133,6 +140,8 @@ class FsmtpTest
      */
     public static function finish($suiteName)
     {
+        self::writeCoverage();
+
         $after = self::protectedTableCounts();
         if (self::$protectedCounts !== $after) {
             self::$currentCase = 'protected production data';
@@ -177,6 +186,59 @@ class FsmtpTest
 
         WP_CLI::log(str_repeat('=', 72));
         WP_CLI::halt(0);
+    }
+
+    /** Start optional PCOV collection before the first suite assertion. */
+    private static function startCoverage()
+    {
+        self::$coverageFile = (string) getenv('FSMTP_COVERAGE_FILE');
+        if (self::$coverageFile === '') {
+            return;
+        }
+
+        if (!function_exists('pcov\\start') || ini_get('pcov.enabled') !== '1') {
+            WP_CLI::error('FSMTP_COVERAGE_FILE requires PHP with pcov.enabled=1.');
+        }
+
+        if (!defined('FSMTP_COVERAGE_STARTED_EARLY')) {
+            \pcov\clear();
+            \pcov\start();
+        }
+        self::$coverageStarted = true;
+    }
+
+    /** Persist only this plugin's production line map for the coverage merger. */
+    private static function writeCoverage()
+    {
+        if (!self::$coverageStarted) {
+            return;
+        }
+
+        \pcov\stop();
+        $collected = \pcov\collect();
+        $root = realpath(dirname(__DIR__, 2));
+        $filtered = [];
+
+        foreach ((array) $collected as $file => $lines) {
+            $realFile = realpath($file);
+            if (!$root || !$realFile || strpos($realFile, $root . DIRECTORY_SEPARATOR) !== 0) {
+                continue;
+            }
+
+            $relative = str_replace(DIRECTORY_SEPARATOR, '/', substr($realFile, strlen($root) + 1));
+            if (!preg_match('#^(app|includes|database)/#', $relative)) {
+                continue;
+            }
+            $filtered[$relative] = $lines;
+        }
+
+        ksort($filtered);
+        $encoded = json_encode($filtered, JSON_UNESCAPED_SLASHES);
+        if ($encoded === false || file_put_contents(self::$coverageFile, $encoded) === false) {
+            self::fail('Could not write PCOV data to the requested coverage file.');
+        }
+
+        self::$coverageStarted = false;
     }
 
     public static function case($name, callable $callback)

--- a/tests/lib/harness.php
+++ b/tests/lib/harness.php
@@ -83,6 +83,7 @@ class FsmtpTest
      */
     public static function boot()
     {
+        self::applyEnvironmentAxes();
         self::startCoverage();
         self::$startedAt = microtime(true);
 
@@ -115,6 +116,54 @@ class FsmtpTest
         self::clearCaches();
         self::assertMailSimulationActive();
         self::$protectedCounts = self::protectedTableCounts();
+    }
+
+    /**
+     * Apply opt-in axes only inside this WP-CLI process. Filters avoid writing
+     * either install's timezone options, while SESSION sql_mode disappears as
+     * soon as the suite process exits.
+     */
+    private static function applyEnvironmentAxes()
+    {
+        global $wpdb;
+
+        $requestedOffset = getenv('FSMTP_TEST_GMT_OFFSET');
+        if ($requestedOffset !== false && $requestedOffset !== '') {
+            if (!preg_match('/^-?(?:\d+|\d*\.\d+)$/', $requestedOffset)) {
+                throw new RuntimeException('FSMTP_TEST_GMT_OFFSET must be numeric.');
+            }
+
+            $offset = (float)$requestedOffset;
+            if ($offset < -12 || $offset > 14) {
+                throw new RuntimeException('FSMTP_TEST_GMT_OFFSET must be between -12 and +14.');
+            }
+
+            add_filter('pre_option_timezone_string', function () {
+                return '';
+            }, PHP_INT_MAX);
+            add_filter('pre_option_gmt_offset', function () use ($offset) {
+                return $offset;
+            }, PHP_INT_MAX);
+        }
+
+        if (getenv('FSMTP_TEST_STRICT_SQL')) {
+            $current = array_filter(array_map('trim', explode(
+                ',',
+                (string)$wpdb->get_var('SELECT @@SESSION.sql_mode')
+            )));
+            $modes = array_values(array_unique(array_merge(
+                $current,
+                ['ONLY_FULL_GROUP_BY', 'STRICT_TRANS_TABLES']
+            )));
+            $result = $wpdb->query($wpdb->prepare(
+                'SET SESSION sql_mode = %s',
+                implode(',', $modes)
+            ));
+
+            if ($result === false) {
+                throw new RuntimeException('Could not enable strict SQL modes: ' . $wpdb->last_error);
+            }
+        }
     }
 
     /**
@@ -279,6 +328,25 @@ class FsmtpTest
     {
         self::$skipped++;
         WP_CLI::log('  SKIP ' . (self::$currentCase ?: '') . ' — ' . $reason);
+    }
+
+    /**
+     * Keep a confirmed production defect visible without making the default
+     * regression gate red. Strict-known-failure runs still fail for fix passes.
+     */
+    public static function knownFailure($condition, $detail)
+    {
+        if (!$condition) {
+            return false;
+        }
+
+        $message = 'KNOWN-FAILURE: ' . $detail;
+        if (getenv('FSMTP_STRICT_KNOWN_FAILURES') === '1') {
+            self::fail($message);
+        } else {
+            WP_CLI::log('  ' . (self::$currentCase ?: '(no case)') . ' — ' . $message);
+        }
+        return true;
     }
 
     public static function assert($condition, $detail)

--- a/tests/lib/harness.php
+++ b/tests/lib/harness.php
@@ -1,0 +1,491 @@
+<?php
+/**
+ * FluentSMTP local WP-CLI test harness.
+ *
+ * Adapted from the wp-plugin-test-suite asset. AJAX is dispatched in-process
+ * so the same PHP process can see database errors and plugin diagnostics.
+ */
+
+if (!defined('WP_CLI') || !WP_CLI) {
+    exit("FluentSMTP tests must run via WP-CLI.\n");
+}
+
+$fsmtpSuiteConfig = require dirname(__DIR__) . '/suite.config.php';
+
+if (!class_exists($fsmtpSuiteConfig['sentinel_class'])) {
+    WP_CLI::error('FluentSMTP is not active on this site.');
+}
+
+// The plugin is already loaded by WP-CLI, but the provider seam is evaluated
+// at send time. Defining this here therefore closes the transport before any
+// suite case can resolve a provider.
+if (!defined('FLUENTMAIL_SIMULATE_EMAILS')) {
+    define('FLUENTMAIL_SIMULATE_EMAILS', true);
+}
+
+// Extending Error keeps a completed wp_send_json() response from being mistaken
+// for an application Exception by controller catch blocks.
+class FsmtpAjaxExit extends Error
+{
+}
+
+class FsmtpTest
+{
+    /** @var array<int,array{name:string,detail:string}> */
+    public static $failures = [];
+
+    /** @var int */
+    public static $passed = 0;
+
+    /** @var int */
+    public static $skipped = 0;
+
+    /** @var array<int,string> */
+    private static $diagnostics = [];
+
+    /** @var string|null */
+    private static $currentCase = null;
+
+    /** @var float */
+    private static $startedAt = 0.0;
+
+    /** @var array<string,int> */
+    private static $protectedCounts = [];
+
+    /** @var array<int,array{url:string,args:array}> */
+    private static $httpRequests = [];
+
+    /** @var callable|null */
+    private static $httpInterceptor = null;
+
+    /** @var bool */
+    private static $routesLoaded = false;
+
+    /** @return array<string,mixed> */
+    public static function config()
+    {
+        static $config;
+        if ($config === null) {
+            $config = require dirname(__DIR__) . '/suite.config.php';
+        }
+        return $config;
+    }
+
+    /**
+     * Install fail-closed diagnostics, register admin routes for WP-CLI, and
+     * select an administrator for read-only smoke calls.
+     */
+    public static function boot()
+    {
+        self::$startedAt = microtime(true);
+
+        $hint = self::config()['plugin_dir_hint'];
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use ($hint) {
+            if (!(error_reporting() & $errno)) {
+                return false;
+            }
+
+            if (strpos(str_replace('\\', '/', $errfile), $hint) === false) {
+                return false;
+            }
+
+            self::$diagnostics[] = self::errorLabel($errno) . ': ' . $errstr
+                . ' (' . self::relPath($errfile) . ':' . $errline . ')';
+            return true;
+        });
+
+        $admins = get_users([
+            'role'    => 'administrator',
+            'number'  => 1,
+            'orderby' => 'ID',
+        ]);
+        if (!$admins) {
+            WP_CLI::error('No administrator user found on this site.');
+        }
+        wp_set_current_user($admins[0]->ID);
+
+        self::loadAdminRoutes();
+        self::clearCaches();
+        self::assertMailSimulationActive();
+        self::$protectedCounts = self::protectedTableCounts();
+    }
+
+    /**
+     * Admin routes are conditionally included behind is_admin() in production;
+     * WP-CLI is not an admin request, so the test harness includes the same
+     * route file with the real application instance in scope.
+     */
+    private static function loadAdminRoutes()
+    {
+        if (self::$routesLoaded) {
+            return;
+        }
+
+        $bootstrap = self::config()['app_bootstrap'];
+        $app = $bootstrap();
+        require dirname(__DIR__, 2) . '/' . self::config()['routes_file'];
+        self::$routesLoaded = true;
+    }
+
+    /**
+     * Print a summary and leave WP-CLI non-zero on any failure. Protected log
+     * counts are compared here even when a runner throws before its own cleanup.
+     */
+    public static function finish($suiteName)
+    {
+        $after = self::protectedTableCounts();
+        if (self::$protectedCounts !== $after) {
+            self::$currentCase = 'protected production data';
+            self::fail(
+                "FluentSMTP protected row-count drift\n  before: "
+                . var_export(self::$protectedCounts, true)
+                . "\n  after:  " . var_export($after, true)
+            );
+            self::$currentCase = null;
+        }
+
+        restore_error_handler();
+        self::releaseHttpInterceptor();
+
+        $elapsed = round(microtime(true) - self::$startedAt, 1);
+        $total = self::$passed + count(self::$failures);
+
+        WP_CLI::log('');
+        WP_CLI::log(str_repeat('=', 72));
+        WP_CLI::log(sprintf(
+            '%s: %d/%d passed, %d failed, %d skipped  (%ss)',
+            $suiteName,
+            self::$passed,
+            $total,
+            count(self::$failures),
+            self::$skipped,
+            $elapsed
+        ));
+
+        if (self::$failures) {
+            WP_CLI::log('');
+            foreach (self::$failures as $index => $failure) {
+                WP_CLI::log(sprintf('%d) %s', $index + 1, $failure['name']));
+                foreach (explode("\n", rtrim($failure['detail'])) as $line) {
+                    WP_CLI::log('   ' . $line);
+                }
+                WP_CLI::log('');
+            }
+            WP_CLI::log(str_repeat('=', 72));
+            WP_CLI::halt(1);
+        }
+
+        WP_CLI::log(str_repeat('=', 72));
+        WP_CLI::halt(0);
+    }
+
+    public static function case($name, callable $callback)
+    {
+        self::$currentCase = $name;
+        self::$diagnostics = [];
+        $failedBefore = count(self::$failures);
+
+        try {
+            // This is deliberately repeated for every case. A send-path test is
+            // never allowed to rely on an earlier case's safety assertion.
+            self::assertMailSimulationActive();
+            $callback();
+        } catch (Throwable $e) {
+            self::fail('threw ' . get_class($e) . ': ' . $e->getMessage()
+                . ' (' . self::relPath($e->getFile()) . ':' . $e->getLine() . ')');
+        }
+
+        if (self::$diagnostics) {
+            self::fail("PHP diagnostics raised:\n  - " . implode("\n  - ", self::$diagnostics));
+        }
+
+        if (count(self::$failures) === $failedBefore) {
+            self::$passed++;
+        }
+        self::$currentCase = null;
+    }
+
+    public static function fail($detail)
+    {
+        self::$failures[] = [
+            'name'   => self::$currentCase ?: '(no case)',
+            'detail' => $detail,
+        ];
+    }
+
+    public static function skip($reason)
+    {
+        self::$skipped++;
+        WP_CLI::log('  SKIP ' . (self::$currentCase ?: '') . ' — ' . $reason);
+    }
+
+    public static function assert($condition, $detail)
+    {
+        if (!$condition) {
+            self::fail($detail);
+        }
+    }
+
+    public static function assertSame($expected, $actual, $label)
+    {
+        if ($expected !== $actual) {
+            self::fail($label . "\n  expected: " . var_export($expected, true)
+                . "\n  actual:   " . var_export($actual, true));
+        }
+    }
+
+    /**
+     * Dispatch one registered admin-AJAX action in-process.
+     *
+     * The action name is always obtained by calling Application::getAjaxAction;
+     * the harness never reproduces the plugin's string-building rules.
+     *
+     * @return array{action:string,status:int,data:mixed,raw:string,db_error:string,terminated:bool}
+     */
+    public static function ajax($method, $route, array $params = [])
+    {
+        global $wpdb;
+
+        $bootstrap = self::config()['app_bootstrap'];
+        $app = $bootstrap();
+        $method = strtolower($method);
+        $hook = $app->getAjaxAction($route, $method, true);
+        $requestAction = substr($hook, strlen('wp_ajax_'));
+        $nonce = wp_create_nonce(FLUENTMAIL);
+
+        $payload = array_merge($params, [
+            'action' => $requestAction,
+            'nonce'  => $nonce,
+        ]);
+        $get = $method === 'get' ? $payload : [];
+        $post = $method === 'post' ? $payload : [];
+
+        $requestClass = self::config()['request_class'];
+        $request = new $requestClass($app, $get, $post, []);
+        $app->instance($requestClass, $request);
+
+        $oldGet = $_GET;
+        $oldPost = $_POST;
+        $oldRequest = $_REQUEST;
+        $oldServerMethod = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : null;
+
+        $_GET = $get;
+        $_POST = $post;
+        $_REQUEST = $payload;
+        $_SERVER['REQUEST_METHOD'] = strtoupper($method);
+        $wpdb->last_error = '';
+
+        if (!defined('DOING_AJAX')) {
+            define('DOING_AJAX', true);
+        }
+
+        $dieHandler = function () {
+            return function ($message = '', $title = '', $args = []) {
+                throw new FsmtpAjaxExit('AJAX response completed.');
+            };
+        };
+        add_filter('wp_die_ajax_handler', $dieHandler, PHP_INT_MAX);
+
+        $raw = '';
+        $terminated = false;
+        $status = 200;
+        ob_start();
+        try {
+            if (!has_action($hook)) {
+                throw new RuntimeException('No callback is registered for derived action ' . $hook);
+            }
+            do_action($hook);
+        } catch (FsmtpAjaxExit $e) {
+            $terminated = true;
+        } finally {
+            $raw = (string) ob_get_clean();
+            $httpStatus = http_response_code();
+            if (is_int($httpStatus) && $httpStatus >= 100) {
+                $status = $httpStatus;
+            }
+
+            remove_filter('wp_die_ajax_handler', $dieHandler, PHP_INT_MAX);
+            $_GET = $oldGet;
+            $_POST = $oldPost;
+            $_REQUEST = $oldRequest;
+            if ($oldServerMethod === null) {
+                unset($_SERVER['REQUEST_METHOD']);
+            } else {
+                $_SERVER['REQUEST_METHOD'] = $oldServerMethod;
+            }
+        }
+
+        $data = json_decode(trim($raw), true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $data = null;
+        }
+
+        return [
+            'action'     => $hook,
+            'status'     => $status,
+            'data'       => $data,
+            'raw'        => $raw,
+            'db_error'   => (string) $wpdb->last_error,
+            'terminated' => $terminated,
+        ];
+    }
+
+    /** Require a usable JSON AJAX response with no database failure. */
+    public static function assertAjaxHealthy(array $result, $label)
+    {
+        if ($result['db_error'] !== '') {
+            self::fail($label . "\n  DATABASE ERROR: " . $result['db_error']);
+            return;
+        }
+        if (!$result['terminated']) {
+            self::fail($label . "\n  action returned without completing a JSON response");
+            return;
+        }
+        if (!is_array($result['data'])) {
+            self::fail($label . "\n  invalid JSON response: " . trim($result['raw']));
+            return;
+        }
+        if (isset($result['data']['success']) && $result['data']['success'] === false) {
+            self::fail($label . "\n  AJAX error response: " . self::responseMessage($result['data']));
+        }
+    }
+
+    /** Resolve an action only through the production method. */
+    public static function ajaxAction($method, $route, $isAdmin = true)
+    {
+        $bootstrap = self::config()['app_bootstrap'];
+        return $bootstrap()->getAjaxAction($route, strtolower($method), $isAdmin);
+    }
+
+    /**
+     * Fail closed for every WordPress HTTP request. The optional callback may
+     * return a normal WordPress HTTP response fixture for expected endpoints.
+     */
+    public static function interceptHttp(?callable $responder = null)
+    {
+        self::$httpRequests = [];
+        self::releaseHttpInterceptor();
+
+        self::$httpInterceptor = function ($preempt, $args, $url) use ($responder) {
+            self::$httpRequests[] = [
+                'url'  => (string) $url,
+                'args' => is_array($args) ? $args : [],
+            ];
+
+            if ($responder) {
+                $response = $responder((string) $url, is_array($args) ? $args : []);
+                if ($response !== null) {
+                    return $response;
+                }
+            }
+
+            return new WP_Error(
+                'fsmtp_test_http_blocked',
+                'Outbound HTTP blocked by the FluentSMTP test harness: ' . $url
+            );
+        };
+
+        add_filter('pre_http_request', self::$httpInterceptor, PHP_INT_MAX, 3);
+    }
+
+    public static function releaseHttpInterceptor()
+    {
+        if (self::$httpInterceptor !== null) {
+            remove_filter('pre_http_request', self::$httpInterceptor, PHP_INT_MAX);
+            self::$httpInterceptor = null;
+        }
+    }
+
+    /** @return array<int,array{url:string,args:array}> */
+    public static function httpRequests()
+    {
+        return self::$httpRequests;
+    }
+
+    /**
+     * Prove the plugin's own provider resolver chose Simulator. A constant check
+     * alone is not enough: this asserts the runtime seam used by actual sends.
+     */
+    public static function assertMailSimulationActive()
+    {
+        if (!defined('FLUENTMAIL_SIMULATE_EMAILS') || !FLUENTMAIL_SIMULATE_EMAILS) {
+            throw new RuntimeException('FLUENTMAIL_SIMULATE_EMAILS is not truthy.');
+        }
+
+        $handler = fluentMailGetProvider('fsmtp-suite-safety@example.test', true);
+        if (!$handler instanceof \FluentMail\App\Services\Mailer\Providers\Simulator\Handler) {
+            throw new RuntimeException(
+                'fluentMailGetProvider() did not resolve the Simulator handler.'
+            );
+        }
+        return true;
+    }
+
+    /** Clear only FluentSMTP-owned transient/object-cache entries. */
+    public static function clearCaches()
+    {
+        global $wpdb;
+        $rows = $wpdb->get_col(
+            "SELECT option_name FROM {$wpdb->options}
+             WHERE option_name LIKE '\\_transient\\_fluentmail%'
+                OR option_name LIKE '\\_transient\\_timeout\\_fluentmail%'
+                OR option_name LIKE '\\_transient\\_fluentsmtp%'
+                OR option_name LIKE '\\_transient\\_timeout\\_fluentsmtp%'"
+        );
+
+        foreach ($rows as $name) {
+            $key = preg_replace('/^_transient_(timeout_)?/', '', $name);
+            delete_transient($key);
+        }
+        return count($rows);
+    }
+
+    /** @return array<string,int> */
+    public static function protectedTableCounts()
+    {
+        global $wpdb;
+        $counts = [];
+        foreach (self::config()['protected_tables'] as $suffix) {
+            $table = $wpdb->prefix . $suffix;
+            $counts[$suffix] = (int) $wpdb->get_var("SELECT COUNT(*) FROM `{$table}`");
+        }
+        return $counts;
+    }
+
+    public static function uniq($prefix = 'fsmtptest')
+    {
+        return $prefix . '-' . strtolower(wp_generate_password(8, false, false));
+    }
+
+    private static function responseMessage(array $data)
+    {
+        if (isset($data['data']['message']) && is_string($data['data']['message'])) {
+            return $data['data']['message'];
+        }
+        if (isset($data['message']) && is_string($data['message'])) {
+            return $data['message'];
+        }
+        return wp_json_encode($data);
+    }
+
+    private static function relPath($file)
+    {
+        $normalized = str_replace('\\', '/', $file);
+        $position = strpos($normalized, '/fluent-smtp/');
+        return $position === false ? basename($normalized) : substr($normalized, $position + 1);
+    }
+
+    private static function errorLabel($errno)
+    {
+        $map = [
+            E_WARNING           => 'Warning',
+            E_NOTICE            => 'Notice',
+            E_USER_WARNING      => 'User Warning',
+            E_USER_NOTICE       => 'User Notice',
+            E_DEPRECATED        => 'Deprecated',
+            E_USER_DEPRECATED   => 'User Deprecated',
+            E_RECOVERABLE_ERROR => 'Recoverable Error',
+        ];
+        return isset($map[$errno]) ? $map[$errno] : ('Error(' . $errno . ')');
+    }
+}

--- a/tests/lib/harness.php
+++ b/tests/lib/harness.php
@@ -459,6 +459,80 @@ class FsmtpTest
         return $counts;
     }
 
+    /**
+     * Run the plugin's real WP-CLI command in a fresh process. The child loads
+     * cli-bootstrap.php before command dispatch, so mail simulation, HTTP and
+     * option-write fuses are enforced inside the process that owns the command.
+     *
+     * @return array{code:int,stdout:string,stderr:string,output:string}
+     */
+    public static function wpCli(array $arguments, array $environment = [])
+    {
+        $candidates = [
+            isset($_SERVER['argv'][0]) ? $_SERVER['argv'][0] : '',
+            getenv('_') ?: '',
+        ];
+        $binary = '';
+
+        foreach ($candidates as $candidate) {
+            if ($candidate && is_file($candidate) && is_executable($candidate)) {
+                $binary = $candidate;
+                break;
+            }
+        }
+
+        if (!$binary) {
+            $located = [];
+            $locateCode = 1;
+            exec('command -v wp 2>/dev/null', $located, $locateCode);
+            if ($locateCode === 0 && !empty($located[0])) {
+                $binary = trim($located[0]);
+            }
+        }
+
+        if (!$binary) {
+            throw new RuntimeException('Could not locate the wp executable for CLI integration tests.');
+        }
+
+        $command = array_merge([
+            $binary,
+            '--path=' . untrailingslashit(ABSPATH),
+            '--require=' . dirname(__DIR__) . '/bin/cli-bootstrap.php',
+            '--no-color',
+        ], $arguments);
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $baseEnvironment = getenv();
+        $process = proc_open(
+            $command,
+            $descriptors,
+            $pipes,
+            null,
+            array_merge(is_array($baseEnvironment) ? $baseEnvironment : [], $environment)
+        );
+
+        if (!is_resource($process)) {
+            throw new RuntimeException('Could not start the WP-CLI child process.');
+        }
+
+        fclose($pipes[0]);
+        $stdout = (string)stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        $stderr = (string)stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+        $code = proc_close($process);
+
+        return [
+            'code'   => (int)$code,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'output' => trim($stdout . "\n" . $stderr),
+        ];
+    }
+
     public static function uniq($prefix = 'fsmtptest')
     {
         return $prefix . '-' . strtolower(wp_generate_password(8, false, false));

--- a/tests/lib/harness.php
+++ b/tests/lib/harness.php
@@ -342,7 +342,7 @@ class FsmtpTest
             return;
         }
         if (!is_array($result['data'])) {
-            self::fail($label . "\n  invalid JSON response: " . trim($result['raw']));
+            self::fail($label . "\n  invalid JSON response (body length " . strlen($result['raw']) . ')');
             return;
         }
         if (isset($result['data']['success']) && $result['data']['success'] === false) {
@@ -355,6 +355,12 @@ class FsmtpTest
     {
         $bootstrap = self::config()['app_bootstrap'];
         return $bootstrap()->getAjaxAction($route, strtolower($method), $isAdmin);
+    }
+
+    /** Extract the human-facing message from a WordPress AJAX envelope. */
+    public static function ajaxMessage(array $result)
+    {
+        return is_array($result['data']) ? self::responseMessage($result['data']) : trim($result['raw']);
     }
 
     /**
@@ -379,9 +385,10 @@ class FsmtpTest
                 }
             }
 
+            $safeUrl = strtok((string) $url, '?');
             return new WP_Error(
                 'fsmtp_test_http_blocked',
-                'Outbound HTTP blocked by the FluentSMTP test harness: ' . $url
+                'Outbound HTTP blocked by the FluentSMTP test harness: ' . $safeUrl
             );
         };
 

--- a/tests/lint/browser-route-coverage.php
+++ b/tests/lint/browser-route-coverage.php
@@ -1,0 +1,55 @@
+<?php
+/** Keep the browser smoke manifest synchronized with every Vue admin route. */
+
+$root = dirname(__DIR__, 2);
+$routesPath = $root . '/resources/admin/routes.js';
+$manifestPath = $root . '/tests/browser/admin-screen-smoke.mjs';
+
+$routesSource = file_get_contents($routesPath);
+$manifestSource = file_get_contents($manifestPath);
+if ($routesSource === false || $manifestSource === false) {
+    fwrite(STDERR, "browser-route-coverage: could not read routes or manifest\n");
+    exit(2);
+}
+
+preg_match_all('/\bpath:\s*([\'\"])(.*?)\1/', $routesSource, $routeMatches);
+preg_match_all('/\bhash:\s*([\'\"])(.*?)\1/', $manifestSource, $manifestMatches);
+
+$declared = $routeMatches[2];
+$listed = $manifestMatches[2];
+$errors = [];
+
+foreach (array_count_values($declared) as $route => $count) {
+    if ($count > 1) {
+        $errors[] = "duplicate Vue route {$route}";
+    }
+}
+foreach (array_count_values($listed) as $route => $count) {
+    if ($count > 1) {
+        $errors[] = "duplicate browser manifest route {$route}";
+    }
+}
+
+foreach (array_diff($declared, $listed) as $route) {
+    $errors[] = "Vue route missing from browser smoke: {$route}";
+}
+foreach (array_diff($listed, $declared) as $route) {
+    $errors[] = "browser smoke route is not declared: {$route}";
+}
+
+echo sprintf(
+    "browser-route-coverage: %d declared, %d manifested\n",
+    count($declared),
+    count($listed)
+);
+
+if ($errors) {
+    echo "\nFAIL — browser route manifest drift:\n";
+    foreach ($errors as $error) {
+        echo "  - {$error}\n";
+    }
+    exit(1);
+}
+
+echo "OK — every FluentSMTP Vue admin route has one browser mount check.\n";
+exit(0);

--- a/tests/lint/fixtures/bad-raw-prefix.php
+++ b/tests/lint/fixtures/bad-raw-prefix.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Intentionally broken FluentSMTP lint fixture. Never loaded by WordPress.
+ *
+ * `php tests/lint/raw-sql-prefix.php tests/lint/fixtures` must report the three
+ * bare `fsmpt_email_logs` identifiers below and ignore the safe controls.
+ */
+
+$brokenSelect = $db->selectRaw('fsmpt_email_logs.status, COUNT(*) AS total');
+$brokenWhere = $db->whereRaw("fsmpt_email_logs.created_at < NOW()");
+$brokenAggregate = $db->raw("SUM(CASE WHEN fsmpt_email_logs.status = 'sent' THEN 1 ELSE 0 END)");
+
+global $wpdb;
+$table = $wpdb->prefix . 'fsmpt_email_logs';
+$safeInterpolated = $db->selectRaw("`{$table}`.`status`, COUNT(*) AS total");
+$safeConcatenated = $db->raw('COUNT(' . $table . '.id) AS total');
+$safeBareColumn = $db->raw("SUM(CASE WHEN status = 'sent' THEN 1 ELSE 0 END)");

--- a/tests/lint/raw-sql-prefix.php
+++ b/tests/lint/raw-sql-prefix.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Static gate: raw SQL must not use a bare table-qualified `fsmpt_*` name.
+ *
+ * Query-builder grammar can apply `$wpdb->prefix`; raw SQL cannot. A default
+ * `wp_` development prefix would otherwise hide this entire defect class.
+ */
+
+$root = is_dir(__DIR__ . '/../../app') ? dirname(__DIR__, 2) : getcwd();
+$scanDirs = ['app', 'includes', 'database'];
+if (isset($argv[1]) && $argv[1] !== '') {
+    $scanDirs = [rtrim($argv[1], '/')];
+}
+
+$rawCallPattern = '/\b(?:selectRaw|whereRaw|havingRaw|orderByRaw|groupByRaw|orWhereRaw|raw)\s*\(/i';
+$qualifiedPattern = '/\bfsmpt_[a-z0-9_]+\s*\./i';
+$prefixEvidence = '/\$wpdb->prefix|getTablePrefix\s*\(|\{\$[a-zA-Z_][a-zA-Z0-9_]*\}|\$[a-zA-Z_][a-zA-Z0-9_]*\s*\./';
+
+$violations = [];
+$scanned = 0;
+
+$iterate = function ($directory) {
+    $paths = [];
+    if (!is_dir($directory)) {
+        return $paths;
+    }
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($iterator as $file) {
+        if (!$file->isFile() || strtolower($file->getExtension()) !== 'php') {
+            continue;
+        }
+        $path = str_replace('\\', '/', $file->getPathname());
+        if (strpos($path, '/vendor/') !== false || strpos($path, '/libs/') !== false) {
+            continue;
+        }
+        $paths[] = $file->getPathname();
+    }
+    return $paths;
+};
+
+foreach ($scanDirs as $directory) {
+    $target = ($directory !== '' && $directory[0] === '/') ? $directory : $root . '/' . $directory;
+    foreach ($iterate($target) as $path) {
+        $scanned++;
+        $lines = file($path, FILE_IGNORE_NEW_LINES);
+        foreach ($lines as $index => $line) {
+            if (!preg_match($rawCallPattern, $line)) {
+                continue;
+            }
+            if (!preg_match_all(
+                '/"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\'/',
+                $line,
+                $matches,
+                PREG_SET_ORDER | PREG_OFFSET_CAPTURE
+            )) {
+                continue;
+            }
+
+            foreach ($matches as $match) {
+                $doubleQuoted = isset($match[1]) ? $match[1][0] : '';
+                $singleQuoted = isset($match[2]) ? $match[2][0] : '';
+                $literal = $singleQuoted !== '' ? $singleQuoted : $doubleQuoted;
+                if (!preg_match($qualifiedPattern, $literal, $hit)) {
+                    continue;
+                }
+                if (preg_match($prefixEvidence, $literal)) {
+                    continue;
+                }
+
+                $before = substr($line, 0, $match[0][1]);
+                if (preg_match(
+                    '/(?:\$wpdb->prefix|getTablePrefix\s*\(\s*\)|\$[a-zA-Z_][a-zA-Z0-9_]*)\s*\.\s*$/',
+                    $before
+                )) {
+                    continue;
+                }
+
+                $violations[] = [
+                    'file'  => str_replace($root . '/', '', $path),
+                    'line'  => $index + 1,
+                    'ident' => trim($hit[0]),
+                    'code'  => trim($line),
+                ];
+            }
+        }
+    }
+}
+
+echo "raw-sql-prefix: scanned {$scanned} PHP files\n";
+if (!$violations) {
+    echo "OK — no unprefixed FluentSMTP table identifiers inside raw SQL.\n";
+    exit(0);
+}
+
+echo "\nFAIL — " . count($violations) . " violation(s):\n\n";
+foreach ($violations as $violation) {
+    echo "  {$violation['file']}:{$violation['line']}\n";
+    echo "    unprefixed identifier: {$violation['ident']}\n";
+    echo "    {$violation['code']}\n\n";
+}
+echo 'Raw SQL bypasses prefix-aware grammar. Resolve $wpdb->prefix explicitly.' . "\n";
+exit(1);

--- a/tests/lint/route-coverage.php
+++ b/tests/lint/route-coverage.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Phase 2 — fail when app/Http/routes.php and the AJAX manifest drift apart.
+ */
+
+$root = dirname(__DIR__, 2);
+$config = require $root . '/tests/suite.config.php';
+$routesPath = $root . '/' . $config['routes_file'];
+$manifestPath = $root . '/' . $config['ajax_manifest'];
+
+$source = file_get_contents($routesPath);
+if ($source === false) {
+    fwrite(STDERR, "route-coverage: cannot read {$routesPath}\n");
+    exit(2);
+}
+
+preg_match_all(
+    '/\$app->(get|post)\(\s*([\'\"])(.*?)\2\s*,\s*([\'\"])(.*?)\4\s*\)/',
+    $source,
+    $matches,
+    PREG_SET_ORDER
+);
+
+$canonical = function ($route) {
+    return $route === '/' ? '/' : ltrim($route, '/');
+};
+
+$declared = [];
+foreach ($matches as $match) {
+    $method = strtoupper($match[1]);
+    $route = $canonical($match[3]);
+    $key = $method . ' ' . $route;
+    if (isset($declared[$key])) {
+        fwrite(STDERR, "route-coverage: duplicate declaration {$key}\n");
+        exit(1);
+    }
+    $declared[$key] = $match[5];
+}
+
+$manifest = require $manifestPath;
+if (!is_array($manifest)) {
+    fwrite(STDERR, "route-coverage: manifest must return an array\n");
+    exit(2);
+}
+
+$listed = [];
+$errors = [];
+foreach ($manifest as $index => $entry) {
+    foreach (['method', 'route', 'handler', 'source', 'cases'] as $required) {
+        if (!array_key_exists($required, $entry)) {
+            $errors[] = "manifest entry {$index} is missing {$required}";
+        }
+    }
+    if ($errors && !isset($entry['method'], $entry['route'])) {
+        continue;
+    }
+
+    $method = strtoupper((string) $entry['method']);
+    $route = $canonical((string) $entry['route']);
+    $key = $method . ' ' . $route;
+    if (isset($listed[$key])) {
+        $errors[] = "duplicate manifest entry {$key}";
+    }
+    $listed[$key] = isset($entry['handler']) ? $entry['handler'] : '';
+
+    if (!in_array($method, ['GET', 'POST'], true)) {
+        $errors[] = "{$key} uses unsupported method {$method}";
+    }
+    if (empty($entry['cases']) || !is_array($entry['cases'])) {
+        $errors[] = "{$key} has no request cases";
+    } else {
+        $labels = [];
+        foreach ($entry['cases'] as $caseIndex => $case) {
+            if (!isset($case['label'], $case['params']) || !is_array($case['params'])) {
+                $errors[] = "{$key} case {$caseIndex} needs label and params";
+                continue;
+            }
+            if (isset($labels[$case['label']])) {
+                $errors[] = "{$key} repeats case label {$case['label']}";
+            }
+            $labels[$case['label']] = true;
+        }
+    }
+
+    if (!empty($entry['source'])) {
+        $sourceFile = preg_replace('/:\d+$/', '', $entry['source']);
+        if (!is_file($root . '/' . $sourceFile)) {
+            $errors[] = "{$key} cites missing source file {$sourceFile}";
+        }
+    }
+}
+
+foreach ($declared as $key => $handler) {
+    if (!array_key_exists($key, $listed)) {
+        $errors[] = "route declaration missing from manifest: {$key}";
+        continue;
+    }
+    if ($listed[$key] !== $handler) {
+        $errors[] = "handler drift for {$key}: routes file={$handler}, manifest={$listed[$key]}";
+    }
+}
+
+foreach ($listed as $key => $handler) {
+    if (!array_key_exists($key, $declared)) {
+        $errors[] = "manifest route is not declared: {$key}";
+    }
+}
+
+$methodCounts = ['GET' => 0, 'POST' => 0];
+foreach (array_keys($declared) as $key) {
+    $methodCounts[strtok($key, ' ')]++;
+}
+
+echo sprintf(
+    "route-coverage: %d declared, %d manifested (GET %d, POST %d)\n",
+    count($declared),
+    count($listed),
+    $methodCounts['GET'],
+    $methodCounts['POST']
+);
+
+if ($errors) {
+    echo "\nFAIL — route manifest drift:\n";
+    foreach ($errors as $error) {
+        echo "  - {$error}\n";
+    }
+    exit(1);
+}
+
+echo "OK — every FluentSMTP admin-AJAX route has one matching manifest entry.\n";
+exit(0);

--- a/tests/smoke/mutating.manifest.php
+++ b/tests/smoke/mutating.manifest.php
@@ -1,0 +1,8 @@
+<?php
+/** Return the POST subset of the single authoritative 42-route manifest. */
+
+$manifest = require __DIR__ . '/routes.manifest.php';
+
+return array_values(array_filter($manifest, function ($entry) {
+    return $entry['method'] === 'POST';
+}));

--- a/tests/smoke/routes.manifest.php
+++ b/tests/smoke/routes.manifest.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * All 42 routes from app/Http/routes.php.
+ *
+ * GET variations mirror the actual values/options in resources/admin. POST
+ * payloads preserve the request shapes used by the SPA and are intentionally
+ * inert so the permission runner can dispatch them behind its safety fuses.
+ */
+
+$post = function ($route, $handler, $source, array $params = []) {
+    return [
+        'method'  => 'POST',
+        'route'   => $route,
+        'handler' => $handler,
+        'source'  => $source,
+        'cases'   => [
+            ['label' => 'SPA payload', 'params' => $params],
+        ],
+    ];
+};
+
+return [
+    [
+        'method' => 'GET', 'route' => '/', 'handler' => 'DashboardController@index',
+        'source' => 'resources/admin/Modules/Dashboard/Dashboard.vue:198',
+        'cases' => [['label' => 'dashboard mount', 'params' => []]],
+    ],
+    [
+        'method' => 'GET', 'route' => '/day-time-stats', 'handler' => 'DashboardController@getDayTimeStats',
+        'source' => 'resources/admin/Modules/Dashboard/Charts/ByDayTimeSending.vue:110',
+        'cases' => [
+            ['label' => 'last 7 days', 'params' => ['last_day' => 7]],
+            ['label' => 'last 30 days', 'params' => ['last_day' => 30]],
+            ['label' => 'all time', 'params' => ['last_day' => 0]],
+        ],
+    ],
+    [
+        'method' => 'GET', 'route' => 'sending_stats', 'handler' => 'DashboardController@getSendingStats',
+        'source' => 'resources/admin/Modules/Dashboard/Charts/Emails.vue:29',
+        'cases' => [
+            ['label' => 'initial empty date range', 'params' => ['date_range' => '']],
+            ['label' => 'last week', 'params' => ['date_range' => ['{7_days_ago}', '{today}']]],
+            ['label' => 'last month', 'params' => ['date_range' => ['{30_days_ago}', '{today}']]],
+            ['label' => 'last 3 months', 'params' => ['date_range' => ['{90_days_ago}', '{today}']]],
+        ],
+    ],
+    [
+        'method' => 'GET', 'route' => '/settings', 'handler' => 'SettingsController@index',
+        'source' => 'resources/admin/Modules/Settings/Connections.vue:119',
+        'cases' => [['label' => 'connections screen', 'params' => []]],
+    ],
+    $post('/settings/validate', 'SettingsController@validate', 'app/Http/routes.php:7', [
+        'provider' => ['key' => 'smtp'],
+        'sender_email' => 'invalid',
+    ]),
+    $post('/settings', 'SettingsController@store', 'resources/admin/Modules/Settings/ConnectionWizard.vue:194', [
+        'connection_key' => '',
+        'connection' => ['provider' => 'smtp', 'sender_email' => 'invalid'],
+        'valid_senders' => [],
+    ]),
+    $post('/misc-settings', 'SettingsController@storeMiscSettings', 'resources/admin/Modules/Settings/_GeneralSettings.vue:138', [
+        'settings' => [],
+    ]),
+    $post('/settings/delete', 'SettingsController@delete', 'resources/admin/Modules/Settings/Connections.vue:142', [
+        'key' => 'fsmtp-suite-missing-connection',
+    ]),
+    $post('/settings/misc', 'SettingsController@storeGlobals', 'app/Http/routes.php:11', []),
+    $post('/settings/test', 'SettingsController@sendTestEmil', 'resources/admin/Modules/Test/Test.vue:115', [
+        'email' => 'fsmtp-suite@example.test', 'from' => '', 'isHtml' => 'true',
+    ]),
+    $post('/settings/subscribe', 'SettingsController@subscribe', 'resources/admin/Pieces/_Subscrbe.vue:56', [
+        'email' => 'fsmtp-suite@example.test', 'display_name' => 'FluentSMTP Suite', 'share_essentials' => 'no',
+    ]),
+    $post('/settings/subscribe-dismiss', 'SettingsController@subscribeDismiss', 'resources/admin/Pieces/_SubscribeDismiss.vue:10'),
+    [
+        'method' => 'GET', 'route' => 'settings/connection_info', 'handler' => 'SettingsController@getConnectionInfo',
+        'source' => 'resources/admin/Modules/Settings/ConnectionDetails.vue:66',
+        'cases' => [[
+            'label' => 'connection details request shape',
+            'params' => ['connection_id' => '{missing_connection}'],
+        ]],
+    ],
+    $post('settings/add_new_sender_email', 'SettingsController@addNewSenderEmail', 'resources/admin/Modules/Settings/ConnectionDetails.vue:109', [
+        'connection_id' => 'fsmtp-suite-missing-connection', 'new_sender' => 'fsmtp-suite@example.test',
+    ]),
+    $post('settings/remove_sender_email', 'SettingsController@removeSenderEmail', 'resources/admin/Modules/Settings/ConnectionDetails.vue:136', [
+        'connection_id' => 'fsmtp-suite-missing-connection', 'email' => 'fsmtp-suite@example.test',
+    ]),
+    [
+        'method' => 'GET', 'route' => 'settings/notification-settings', 'handler' => 'SettingsController@getNotificationSettings',
+        'source' => 'resources/admin/Modules/NotificationSettings/NotificationSettings.vue:40',
+        'cases' => [['label' => 'notification screen mount', 'params' => []]],
+    ],
+    $post('settings/notification-settings', 'SettingsController@saveNotificationSettings', 'resources/admin/Modules/NotificationSettings/_EmailSummaryForm.vue:64', [
+        'settings' => ['enabled' => 'no', 'notify_email' => '{site_admin}', 'notify_days' => ['Mon']],
+    ]),
+    [
+        'method' => 'GET', 'route' => 'settings/notification-channels', 'handler' => 'SettingsController@getNotificationChannels',
+        'source' => 'resources/admin/Modules/NotificationSettings/NotificationManager.vue:119',
+        'cases' => [['label' => 'channel list mount', 'params' => []]],
+    ],
+    $post('settings/notification-channels/toggle', 'SettingsController@toggleNotificationChannel', 'resources/admin/Modules/NotificationSettings/_AlertListTable.vue:127', [
+        'channel_keys' => [],
+    ]),
+    $post('settings/gmail_auth_url', 'SettingsController@getGmailAuthUrl', 'resources/admin/Modules/Settings/Partials/Providers/Gmail.vue:137', [
+        'connection' => ['key_store' => 'db', 'client_id' => '', 'client_secret' => ''],
+    ]),
+    $post('settings/outlook_auth_url', 'SettingsController@getOutlookAuthUrl', 'resources/admin/Modules/Settings/Partials/Providers/Outlook.vue:131', [
+        'connection' => ['key_store' => 'wp_config', 'client_id' => '', 'client_secret' => ''],
+    ]),
+    $post('settings/telegram/issue-pin-code', 'TelegramController@issuePinCode', 'resources/admin/Modules/NotificationSettings/_TelegramNotification.vue:82', [
+        'settings' => ['user_email' => 'invalid', 'terms' => 'no'],
+    ]),
+    $post('settings/telegram/confirm', 'TelegramController@confirmConnection', 'resources/admin/Modules/NotificationSettings/_TelegramNotification.vue:100', [
+        'site_token' => '',
+    ]),
+    [
+        'method' => 'GET', 'route' => 'settings/telegram/info', 'handler' => 'TelegramController@getTelegramConnectionInfo',
+        'source' => 'resources/admin/Modules/NotificationSettings/_TelegramConnectionInfo.vue:61',
+        'cases' => [['label' => 'telegram panel mount', 'params' => []]],
+    ],
+    $post('settings/telegram/send-test', 'TelegramController@sendTestMessage', 'resources/admin/Modules/NotificationSettings/_ChannelActions.vue:76'),
+    $post('settings/telegram/disconnect', 'TelegramController@disconnect', 'resources/admin/Modules/NotificationSettings/_ChannelActions.vue:61'),
+    $post('settings/slack/register', 'SlackController@registerSite', 'resources/admin/Modules/NotificationSettings/_SlackNotification.vue:77', [
+        'settings' => ['user_email' => 'invalid', 'terms' => 'no'],
+    ]),
+    $post('settings/slack/send-test', 'SlackController@sendTestMessage', 'resources/admin/Modules/NotificationSettings/_ChannelActions.vue:76'),
+    $post('settings/slack/disconnect', 'SlackController@disconnect', 'resources/admin/Modules/NotificationSettings/_ChannelActions.vue:61'),
+    $post('settings/discord/register', 'DiscordController@registerSite', 'resources/admin/Modules/NotificationSettings/_DiscordNotification.vue:73', [
+        'settings' => ['webhook_url' => '', 'channel_name' => ''],
+    ]),
+    $post('settings/discord/send-test', 'DiscordController@sendTestMessage', 'resources/admin/Modules/NotificationSettings/_ChannelActions.vue:76'),
+    $post('settings/discord/disconnect', 'DiscordController@disconnect', 'resources/admin/Modules/NotificationSettings/_ChannelActions.vue:61'),
+    $post('settings/pushover/register', 'PushoverController@registerSite', 'resources/admin/Modules/NotificationSettings/_PushoverNotification.vue:73', [
+        'settings' => ['api_token' => '', 'user_key' => ''],
+    ]),
+    $post('settings/pushover/send-test', 'PushoverController@sendTestMessage', 'resources/admin/Modules/NotificationSettings/_ChannelActions.vue:76'),
+    $post('settings/pushover/disconnect', 'PushoverController@disconnect', 'resources/admin/Modules/NotificationSettings/_ChannelActions.vue:61'),
+    [
+        'method' => 'GET', 'route' => '/logs', 'handler' => 'LoggerController@get',
+        'source' => 'resources/admin/Modules/Logger/Logs.vue:210',
+        'cases' => [
+            ['label' => 'default table state', 'params' => ['per_page' => 10, 'page' => 1, 'status' => '', 'date_range' => [], 'search' => '']],
+            ['label' => 'page 2', 'params' => ['per_page' => 10, 'page' => 2, 'status' => '', 'date_range' => [], 'search' => '']],
+            ['label' => '20 rows', 'params' => ['per_page' => 20, 'page' => 1, 'status' => '', 'date_range' => [], 'search' => '']],
+            ['label' => '50 rows', 'params' => ['per_page' => 50, 'page' => 1, 'status' => '', 'date_range' => [], 'search' => '']],
+            ['label' => '80 rows', 'params' => ['per_page' => 80, 'page' => 1, 'status' => '', 'date_range' => [], 'search' => '']],
+            ['label' => '100 rows', 'params' => ['per_page' => 100, 'page' => 1, 'status' => '', 'date_range' => [], 'search' => '']],
+            ['label' => '120 rows', 'params' => ['per_page' => 120, 'page' => 1, 'status' => '', 'date_range' => [], 'search' => '']],
+            ['label' => '150 rows', 'params' => ['per_page' => 150, 'page' => 1, 'status' => '', 'date_range' => [], 'search' => '']],
+            ['label' => 'successful status', 'params' => ['per_page' => 10, 'page' => 1, 'status' => 'sent', 'date_range' => [], 'search' => '']],
+            ['label' => 'failed status', 'params' => ['per_page' => 10, 'page' => 1, 'status' => 'failed', 'date_range' => [], 'search' => '']],
+            ['label' => 'today', 'params' => ['per_page' => 10, 'page' => 1, 'status' => '', 'date_range' => ['{today}', '{today}'], 'search' => '']],
+            ['label' => 'last week', 'params' => ['per_page' => 10, 'page' => 1, 'status' => '', 'date_range' => ['{7_days_ago}', '{today}'], 'search' => '']],
+            ['label' => 'last month', 'params' => ['per_page' => 10, 'page' => 1, 'status' => '', 'date_range' => ['{30_days_ago}', '{today}'], 'search' => '']],
+            ['label' => 'last 3 months', 'params' => ['per_page' => 10, 'page' => 1, 'status' => '', 'date_range' => ['{90_days_ago}', '{today}'], 'search' => '']],
+            ['label' => 'search query', 'params' => ['per_page' => 10, 'page' => 1, 'status' => '', 'date_range' => [], 'search' => '{search}']],
+            ['label' => 'combined router query', 'params' => ['per_page' => 20, 'page' => 2, 'status' => 'failed', 'date_range' => ['{30_days_ago}', '{today}'], 'search' => '{search}']],
+        ],
+    ],
+    [
+        'method' => 'GET', 'route' => '/logs/show', 'handler' => 'LoggerController@show',
+        'source' => 'resources/admin/Modules/Logger/LogViewer.vue:183',
+        'cases' => [
+            ['label' => 'viewer opens', 'needs_log' => true, 'params' => ['id' => '{log_id}', 'dir' => null, 'query' => null, 'filter_by' => null, 'filter_by_value' => null]],
+            ['label' => 'viewer next', 'needs_log' => true, 'params' => ['id' => '{log_id}', 'dir' => 'next', 'query' => null, 'filter_by' => null, 'filter_by_value' => null]],
+            ['label' => 'viewer previous', 'needs_log' => true, 'params' => ['id' => '{log_id}', 'dir' => 'prev', 'query' => null, 'filter_by' => null, 'filter_by_value' => null]],
+        ],
+    ],
+    $post('/logs/retry', 'LoggerController@retry', 'resources/admin/Modules/Logger/Logs.vue:282', [
+        'id' => 2147483647, 'type' => 'retry',
+    ]),
+    $post('/logs/retry-bulk', 'LoggerController@retryBulk', 'resources/admin/Modules/Logger/Logs.vue:389', [
+        'log_ids' => [],
+    ]),
+    $post('/logs/delete', 'LoggerController@delete', 'resources/admin/Modules/Logger/Logs.vue:331', [
+        'id' => 2147483647,
+    ]),
+    $post('install_plugin', 'SettingsController@installPlugin', 'resources/admin/Modules/Misc/Support.vue:186', [
+        'plugin_slug' => 'fsmtp-suite-invalid',
+    ]),
+    [
+        'method' => 'GET', 'route' => 'docs', 'handler' => 'DashboardController@getDocs',
+        'source' => 'resources/admin/Modules/Misc/Docs.vue:117',
+        'cases' => [['label' => 'documentation screen', 'params' => []]],
+    ],
+];

--- a/tests/suite.config.php
+++ b/tests/suite.config.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * FluentSMTP local test-suite configuration.
+ *
+ * Keep plugin-specific wiring here. Runners and the harness consume these
+ * values so they do not hardcode the install path, WordPress prefix, or AJAX
+ * action format.
+ */
+
+return [
+    'plugin_slug'       => 'fluent-smtp',
+    'plugin_dir_hint'   => 'plugins/fluent-smtp',
+    'routes_file'       => 'app/Http/routes.php',
+    'table_prefix'      => 'fsmpt_',
+    'protected_tables'  => ['fsmpt_email_logs'],
+    'app_bootstrap'     => 'fluentMail',
+    'request_class'     => 'FluentMail\\Includes\\Request\\Request',
+    'sentinel_class'    => 'FluentMail\\Includes\\Core\\Application',
+    'cache_groups'      => [],
+    'loopback_filter'   => '',
+    'ajax_manifest'     => 'tests/smoke/routes.manifest.php',
+];

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['tests/js/**/*.test.js'],
+        clearMocks: true
+    }
+});


### PR DESCRIPTION
## Summary

Adds a local WP-CLI test suite for FluentSMTP and fixes the two production
defects it found. Both fixes are small; the suite is the bulk of the diff.

Sits on top of #414, which is already on master.

## Production fixes

**Authorization — notification channels (Critical).** `sendTestMessage()` and
`disconnect()` in the Telegram, Slack, Discord and Pushover controllers did not
call `$this->verify()`. A logged-in subscriber could disconnect any notification
channel and trigger outbound test messages. The permission tier caught this on
its first run, with the bypass visible in the output
(`Slack connection has been disconnected successfully`). Fixed by calling
`verify()` first, matching `registerSite()` in the same controllers.

**Strict SQL — report chart and heatmap (regression, unreleased).** c5a5e41d
replaced `MIN(DATE(created_at))` with a bare non-aggregated expression while
updating the comment to claim ONLY_FULL_GROUP_BY compliance. The result is
rejected outright by MySQL 8 defaults:

> Expression #2 of SELECT list is not in GROUP BY clause and contains
> nonaggregated column ... incompatible with sql_mode=only_full_group_by

That breaks the weekly chart (ranges > 62 days), the monthly chart (> 181 days)
and the day/time heatmap on any host running default MySQL 8. Since c5a5e41d is
unreleased, this would have shipped new in 2.3.0.

Fixed by wrapping the existing deterministic expressions in `MIN()`, which is
exact because every row in a bucket shares the same value, and by ordering the
heatmap through `MIN(WEEKDAY(created_at))` instead of `FIELD(DAYNAME(...))`.
Bucket dates and ordering are unchanged — verified directly under strict mode.

## The suite

Runs locally through WP-CLI against a real install. No Docker, no CI service,
no PHPUnit. Default gate is ~3s.

| Tier | Count |
|---|---|
| static (php -l, raw-SQL-prefix lint, route coverage, lint self-test) | 4 gates |
| admin-AJAX smoke | 33 (11 GET routes × query-param variations) |
| permission smoke | 62 (31 POST routes × anonymous + subscriber) |
| integration | 58 |
| JS unit (vitest) | 3 |
| browser smoke + E2E | 8 screens, 3 flows (opt-in) |

Every case has a recorded proof-of-catch: broken, observed red, restored. The
suite passes on two installs with different table prefixes (`wp_` and
`wptest_`), and under UTC+6, UTC−8 and strict SQL modes.

Mutation audit: 20 mutants, 16 killed (80%), 4 survivors documented in
`tests/MUTATION-AUDIT.md` with follow-ups.

Production code is untouched by the test commits — only the two fixes above
change `app/`.

## Notes for review

- `tests/*` and `vitest.config.mjs` are excluded from the release zip.
- Two mutation survivors (S2/S3) raise a product question rather than a test
  gap: the heatmap `ORDER BY` survives deletion because the controller copies
  rows into a prebuilt matrix, so DB row order isn't observable. Either the
  clause is redundant or row order is an intended contract — deliberately not
  guessed.
- `wp fluent-smtp health` exits non-zero on a broken connection, so it can gate
  a deploy.

## Running it

    bash tests/bin/run-all.sh
    FSMTP_WP_ROOT=/path/to/other-install bash tests/bin/run-all.sh
    FSMTP_STRICT_KNOWN_FAILURES=1 wp eval-file tests/bin/run-integration.php

Two things I'd still flag before you tag 2.3.0, neither blocking the PR:

- The OAuth fixes have never touched a real Microsoft or Google account. Every test uses simulated provider responses. No tier closes that, and it's the work aimed squarely at the "lost connection" reports.
- The E2E runs are the one claim I never independently reproduced — the harness tears itself down. Everything else in this branch I re-ran or re-derived myself.