### PR TITLE
fix: add AWS SES Canada West region

### DIFF
--- a/app/Services/Mailer/Providers/config.php
+++ b/app/Services/Mailer/Providers/config.php
@@ -66,6 +66,7 @@ return [
                 'us-west-1'      => __('US West (N. California)', 'fluent-smtp'),
                 'us-west-2'      => __('US West (Oregon)', 'fluent-smtp'),
                 'ca-central-1'   => __('Canada (Central)', 'fluent-smtp'),
+                'ca-west-1'      => __('Canada West (Calgary)', 'fluent-smtp'),
                 'eu-west-1'      => __('EU (Ireland)', 'fluent-smtp'),
                 'eu-west-2'      => __('EU (London)', 'fluent-smtp'),
                 'eu-west-3'      => __('Europe (Paris)', 'fluent-smtp'),


### PR DESCRIPTION
## What does this PR do and why?

<!-- What: detailed description of the change. Why: the problem or need behind it. Link the issue if one exists: Fixes #123 -->

This PR adds the AWS SES Canada West (Calgary) region (`ca-west-1`) to FluentSMTP's Amazon SES region selector.

AWS provides the SES API in `ca-west-1`, but FluentSMTP's hard-coded region list did not expose it. As SES identities and sending configurations are regional, users operating in Calgary could not select the region containing their SES resources or direct requests to the matching endpoint.

The existing endpoint builder already supports standard AWS regions and resolves Calgary to `email.ca-west-1.amazonaws.com`, so no transport or connection-format changes are required.

## Changes

<!-- List the concrete changes. Delete any that don't apply. -->

- [x] PHP (backend logic, models, services, hooks)

## How to test

<!--
Steps for the reviewer to verify this works.
Be specific — which page, what input, what to expect.
-->

1. Run `wp eval-file tests/bin/run-integration.php -- filter=pure-functions.php` and confirm all cases pass.
2. Open WordPress Admin → FluentSMTP → Settings and start configuring an Amazon SES connection.
3. Open the Region dropdown and confirm `Canada West (Calgary)` is available.
4. Select it and confirm the stored region is `ca-west-1`.
5. Save and reload the connection with valid SES credentials, then confirm the Calgary region remains selected.

## Screenshots
<img width="643" height="455" alt="Screenshot 2026-08-10 at 2 36 18 PM" src="https://github.com/user-attachments/assets/23bdb04e-12d4-4faf-be95-12dd81edce65" />