### PR TITLE
Respect custom attachment names across every provider

### DIFF
--- a/app/Services/Mailer/BaseHandler.php
+++ b/app/Services/Mailer/BaseHandler.php
@@ -682,6 +682,44 @@ class BaseHandler
     }
 
     /**
+     * Resolve the file name an attachment should be delivered under.
+     *
+     * PHPMailer keeps the caller supplied name at index 2 — wp_mail() puts the
+     * attachments array key there — and the file's own base name at index 1, so
+     * a site that stores uploads under randomised names can still send a
+     * readable one. The name is caller controlled, so it is reduced to a bare
+     * file name before it reaches a Content-Disposition header or a provider
+     * payload.
+     *
+     * @param array $attachment One row of PHPMailer::getAttachments()
+     * @return string Empty only when the row carries neither a name nor a path.
+     */
+    protected function getAttachmentName($attachment)
+    {
+        $candidates = [
+            isset($attachment[2]) ? $attachment[2] : '',
+            isset($attachment[0]) ? $attachment[0] : ''
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (!is_string($candidate) || $candidate === '') {
+                continue;
+            }
+
+            // wp_basename() drops any directory part for both separators;
+            // the rest cannot be allowed to break out of a quoted header.
+            $name = str_replace(["\r", "\n", "\0", '"'], '', wp_basename($candidate));
+            $name = trim($name);
+
+            if ($name !== '') {
+                return $name;
+            }
+        }
+
+        return '';
+    }
+
+    /**
      * Securely read file contents with path traversal protection
      *
      * @param string $filePath The file path to read

--- a/app/Services/Mailer/Providers/AmazonSes/Handler.php
+++ b/app/Services/Mailer/Providers/AmazonSes/Handler.php
@@ -112,7 +112,7 @@ class Handler extends BaseHandler
             try {
                 // Use secure file reading with path traversal protection
                 $file = $this->secureFileRead($attachment[0]);
-                $fileName = basename($attachment[0]);
+                $fileName = $this->getAttachmentName($attachment);
 
                 // Get MIME type from the validated real path
                 $realPath = realpath($attachment[0]);

--- a/app/Services/Mailer/Providers/Cloudflare/Handler.php
+++ b/app/Services/Mailer/Providers/Cloudflare/Handler.php
@@ -288,7 +288,7 @@ class Handler extends BaseHandler
 
             try {
                 $file = $this->secureFileRead($attachment[0]);
-                $fileName = basename($attachment[0]);
+                $fileName = $this->getAttachmentName($attachment);
             } catch (\Exception $e) {
                 $this->logAttachmentFailure('Cloudflare', $e);
                 $file = false;

--- a/app/Services/Mailer/Providers/ElasticMail/Handler.php
+++ b/app/Services/Mailer/Providers/ElasticMail/Handler.php
@@ -239,8 +239,7 @@ class Handler extends BaseHandler
             }
 
             //Extracting the file name
-            $filenameonly = explode(DIRECTORY_SEPARATOR, $attpath[0]);
-            $fname = end($filenameonly);
+            $fname = $this->getAttachmentName($attpath);
 
             $mimeType = 'application/octet-stream'; // Default
             if (function_exists('mime_content_type')) {

--- a/app/Services/Mailer/Providers/Mailgun/Handler.php
+++ b/app/Services/Mailer/Providers/Mailgun/Handler.php
@@ -181,7 +181,7 @@ class Handler extends BaseHandler
             try {
                 // Use secure file reading with path traversal protection
                 $file = $this->secureFileRead($attachment[0]);
-                $fileName = basename($attachment[0]);
+                $fileName = $this->getAttachmentName($attachment);
             } catch (\Exception $e) {
                 // Log error and skip this attachment
                 $this->logAttachmentFailure('Mailgun', $e);

--- a/app/Services/Mailer/Providers/PepiPost/Handler.php
+++ b/app/Services/Mailer/Providers/PepiPost/Handler.php
@@ -178,7 +178,7 @@ class Handler extends BaseHandler
             try {
                 // Use secure file reading with path traversal protection
                 $file = $this->secureFileRead($attachment[0]);
-                $fileName = basename($attachment[0]);
+                $fileName = $this->getAttachmentName($attachment);
             } catch (\Exception $e) {
                 // Log error and skip this attachment
                 $this->logAttachmentFailure('PepiPost', $e);

--- a/app/Services/Mailer/Providers/Postmark/Handler.php
+++ b/app/Services/Mailer/Providers/Postmark/Handler.php
@@ -168,7 +168,7 @@ class Handler extends BaseHandler
             try {
                 // Use secure file reading with path traversal protection
                 $file = $this->secureFileRead($attachment[0]);
-                $fileName = basename($attachment[0]);
+                $fileName = $this->getAttachmentName($attachment);
             } catch (\Exception $e) {
                 // Log error and skip this attachment
                 $this->logAttachmentFailure('Postmark', $e);

--- a/app/Services/Mailer/Providers/SendGrid/Handler.php
+++ b/app/Services/Mailer/Providers/SendGrid/Handler.php
@@ -173,7 +173,7 @@ class Handler extends BaseHandler
             try {
                 // Use secure file reading with path traversal protection
                 $file = $this->secureFileRead($attachment[0]);
-                $fileName = basename($attachment[0]);
+                $fileName = $this->getAttachmentName($attachment);
                 $contentId = wp_hash($attachment[0]);
 
                 // Get MIME type from the validated real path

--- a/app/Services/Mailer/Providers/SendInBlue/Handler.php
+++ b/app/Services/Mailer/Providers/SendInBlue/Handler.php
@@ -175,7 +175,7 @@ class Handler extends BaseHandler
 
                 if (in_array($ext, $this->allowedAttachmentExts, true)) {
                     $files[] = [
-                        'name'    => basename($attachment[0]),
+                        'name'    => $this->getAttachmentName($attachment),
                         'content' => base64_encode($file)
                     ];
                 }

--- a/app/Services/Mailer/Providers/Smtp/Handler.php
+++ b/app/Services/Mailer/Providers/Smtp/Handler.php
@@ -123,7 +123,7 @@ class Handler extends BaseHandler
 
             if ($attachments = $this->getParam('attachments')) {
                 foreach ($attachments as $attachment) {
-                    $this->phpMailer->addAttachment($attachment[0], $attachment[7]);
+                    $this->phpMailer->addAttachment($attachment[0], $this->getAttachmentName($attachment));
                 }
             }
 

--- a/app/Services/Mailer/Providers/Smtp2Go/Handler.php
+++ b/app/Services/Mailer/Providers/Smtp2Go/Handler.php
@@ -132,7 +132,7 @@ class Handler extends BaseHandler {
             try {
                 // Use secure file reading with path traversal protection
                 $file = $this->secureFileRead($attachment[0]);
-                $fileName = basename($attachment[0]);
+                $fileName = $this->getAttachmentName($attachment);
 
                 // Get MIME type from the validated real path
                 $realPath = realpath($attachment[0]);

--- a/app/Services/Mailer/Providers/SparkPost/Handler.php
+++ b/app/Services/Mailer/Providers/SparkPost/Handler.php
@@ -173,7 +173,7 @@ class Handler extends BaseHandler
             try {
                 // Use secure file reading with path traversal protection
                 $file = $this->secureFileRead($attachment[0]);
-                $fileName = basename($attachment[0]);
+                $fileName = $this->getAttachmentName($attachment);
 
                 // Get MIME type from the validated real path
                 $realPath = realpath($attachment[0]);

--- a/app/Services/Mailer/Providers/ToSend/Handler.php
+++ b/app/Services/Mailer/Providers/ToSend/Handler.php
@@ -201,7 +201,7 @@ class Handler extends BaseHandler
 
             try {
                 if (is_file($attachment[0]) && is_readable($attachment[0])) {
-                    $fileName = basename($attachment[0]);
+                    $fileName = $this->getAttachmentName($attachment);
                     $file = file_get_contents($attachment[0]);
                     $mimeType = mime_content_type($attachment[0]);
                     $filetype = str_replace(';', '', trim($mimeType));

--- a/app/Services/Mailer/Providers/TransMail/Handler.php
+++ b/app/Services/Mailer/Providers/TransMail/Handler.php
@@ -186,7 +186,7 @@ class Handler extends BaseHandler
             try {
                 // Use secure file reading with path traversal protection
                 $file = $this->secureFileRead($attachment[0]);
-                $fileName = basename($attachment[0]);
+                $fileName = $this->getAttachmentName($attachment);
             } catch (\Exception $e) {
                 // Log error and skip this attachment
                 $this->logAttachmentFailure('TransMail', $e);

--- a/tests/integration/pure-functions.php
+++ b/tests/integration/pure-functions.php
@@ -2,6 +2,7 @@
 
 use FluentMail\App\Http\Controllers\SettingsController;
 use FluentMail\App\Services\ConnectionHealth;
+use FluentMail\App\Services\Mailer\Providers\Simulator\Handler as SimulatorHandler;
 use FluentMail\App\Services\Reporting;
 use FluentMail\Includes\Support\ValidationException;
 
@@ -87,6 +88,52 @@ return function () {
             $message,
             $invoke(new ConnectionHealth(), 'flattenMessage', [new Exception($message)]),
             'ordinary health exception message'
+        );
+    });
+
+    FsmtpTest::case('attachment names prefer the caller supplied name and stay a bare file name', function () use ($invoke, $withoutConstructor) {
+        // getAttachmentName() lives on BaseHandler; every provider reads it, so
+        // any concrete handler proves the shared behavior.
+        $handler = $withoutConstructor(SimulatorHandler::class);
+
+        $nameFor = function ($path, $name) use ($invoke, $handler) {
+            // The shape PHPMailer::getAttachments() returns.
+            return $invoke($handler, 'getAttachmentName', [[
+                0 => $path,
+                1 => basename($path),
+                2 => $name,
+                3 => 'base64',
+                4 => 'application/pdf',
+                5 => false,
+                6 => 'attachment',
+                7 => $name
+            ]]);
+        };
+
+        FsmtpTest::assertSame(
+            'January Invoice.pdf',
+            $nameFor('/var/uploads/9f2c1ab7e4.pdf', 'January Invoice.pdf'),
+            'custom wp_mail() attachment name'
+        );
+        FsmtpTest::assertSame(
+            '9f2c1ab7e4.pdf',
+            $nameFor('/var/uploads/9f2c1ab7e4.pdf', ''),
+            'fallback to the stored file name'
+        );
+        FsmtpTest::assertSame(
+            'passwd',
+            $nameFor('/var/uploads/9f2c1ab7e4.pdf', '../../../etc/passwd'),
+            'directory part stripped from the supplied name'
+        );
+        FsmtpTest::assertSame(
+            'invoice.pdf',
+            $nameFor('/var/uploads/9f2c1ab7e4.pdf', "in\r\nvoice.pdf"),
+            'header break stripped from the supplied name'
+        );
+        FsmtpTest::assertSame(
+            'invoice.pdf',
+            $nameFor('/var/uploads/9f2c1ab7e4.pdf', 'in"voice.pdf'),
+            'quote stripped from the supplied name'
         );
     });
 


### PR DESCRIPTION
Supersedes #402. The report and the diagnosis are @justinkruit's — their client switched to SMTP2GO and started seeing scrambled attachment names, because the files are stored on the server under randomised names for security while a readable name is handed to PHPMailer.

## The bug

`wp_mail()` passes the attachments array key to PHPMailer as the attachment name, which lands at index 2 of each `getAttachments()` row; index 1 keeps the file's own base name. Every provider read `basename($path)`, so the custom name was thrown away and recipients got the stored name.

## The fix

One helper on `BaseHandler` rather than the same expression in every handler:

```php
protected function getAttachmentName($attachment)
```

It prefers the caller supplied name, falls back to the path, and reduces whichever it takes to a bare file name — `wp_basename()` for the directory part, then `\r`, `\n`, `\0` and `"` stripped. That last part matters: `basename()` was doing the normalisation incidentally, and the name is caller controlled, so dropping it in favour of a raw index 2 would let a name break out of a `Content-Disposition` header or a provider's JSON payload. An empty name also falls through to the fallback, which a plain `??` would not do.

Fourteen call sites now go through it. Three of them are ones a per-provider patch misses:

- **AmazonSes** — its `getAttachments()` is unreachable today (SES sends raw MIME, so names already survive), but leaving it behind would let it drift from its siblings.
- **ElasticMail** — the one site that interpolates the name straight into a multipart header, and the only one that hand-rolled the base name via `explode(DIRECTORY_SEPARATOR, …)`.
- **Smtp** — passed index 7, which is the name for a regular attachment but the CID for an embedded image.

## Testing

New case in `tests/integration/pure-functions.php` covering the custom name, the fallback, and the three sanitising paths.

Proof-of-catch, per `tests/AGENT.md`:

- Ignoring index 2 (the behaviour before this change) → red on `custom wp_mail() attachment name`.
- Passing the name through unsanitised → red on the fallback, directory, header-break and quote assertions.

Restored and green: integration `83/83`, all lint/smoke tiers pass, protected log count unchanged. `php -l` clean across all fifteen files. PHPStan reports no new errors in the touched files.
