### PR TITLE
Get the PHPStan run to zero errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",
-        "szepeviktor/phpstan-wordpress": "^2.0"
+        "szepeviktor/phpstan-wordpress": "^2.0",
+        "php-stubs/wp-cli-stubs": "^2.12"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "572d0a1c42fce60c8a4e57e12317b576",
+    "content-hash": "b97e118c0d37e09a2987dd8e9804b7cf",
     "packages": [],
     "packages-dev": [
         {
@@ -57,6 +57,50 @@
                 "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.0"
             },
             "time": "2025-12-03T23:06:24+00:00"
+        },
+        {
+            "name": "php-stubs/wp-cli-stubs",
+            "version": "v2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wp-cli-stubs.git",
+                "reference": "af16401e299a3fd2229bd0fa9a037638a4174a9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wp-cli-stubs/zipball/af16401e299a3fd2229bd0fa9a037638a4174a9d",
+                "reference": "af16401e299a3fd2229bd0fa9a037638a4174a9d",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.3 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WP-CLI function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wp-cli-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress",
+                "wp-cli"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wp-cli-stubs/issues",
+                "source": "https://github.com/php-stubs/wp-cli-stubs/tree/v2.12.0"
+            },
+            "time": "2025-06-10T09:58:05+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/includes/Support/Collection.php
+++ b/includes/Support/Collection.php
@@ -13,6 +13,9 @@ use FluentMail\Includes\Support\Arr;
 use FluentMail\Includes\Support\Contracts\JsonableInterface;
 use FluentMail\Includes\Support\Contracts\ArrayableInterface;
 
+/**
+ * @phpstan-consistent-constructor
+ */
 class Collection implements ArrayAccess, ArrayableInterface, Countable, IteratorAggregate, JsonableInterface, JsonSerializable {
 
 	/**
@@ -720,7 +723,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 *
 	 * @return array
 	 */
-	public function jsonSerialize()
+	public function jsonSerialize(): array
 	{
 		return $this->toArray();
 	}
@@ -741,7 +744,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 *
 	 * @return \ArrayIterator
 	 */
-	public function getIterator()
+	public function getIterator(): ArrayIterator
 	{
 		return new ArrayIterator($this->items);
 	}
@@ -762,7 +765,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 *
 	 * @return int
 	 */
-	public function count()
+	public function count(): int
 	{
 		return count($this->items);
 	}
@@ -773,7 +776,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * @param  mixed  $key
 	 * @return bool
 	 */
-	public function offsetExists($key)
+	public function offsetExists($key): bool
 	{
 		return array_key_exists($key, $this->items);
 	}
@@ -784,6 +787,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * @param  mixed  $key
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($key)
 	{
 		return $this->items[$key];
@@ -796,7 +800,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * @param  mixed  $value
 	 * @return void
 	 */
-	public function offsetSet($key, $value)
+	public function offsetSet($key, $value): void
 	{
 		if (is_null($key))
 		{
@@ -814,7 +818,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * @param  string  $key
 	 * @return void
 	 */
-	public function offsetUnset($key)
+	public function offsetUnset($key): void
 	{
 		unset($this->items[$key]);
 	}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
         - includes/libs/google-api-client/build/vendor/autoload.php
     scanFiles:
         - app/Services/DB/wpfluent.php
+        - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
     excludePaths:
         - includes/libs/
         - app/Services/DB/
@@ -18,3 +19,6 @@ parameters:
         - database/
         - app/Services/DB/
     treatPhpDocTypesAsCertain: false
+    phpVersion:
+        min: 70400
+        max: 80400


### PR DESCRIPTION
Follow-up to #399, which took the run from 53 errors to 39. This clears the remaining 39.

### What was left

**WP-CLI symbols (13 errors, `app/Services/CliHandler.php`)**
`WP_CLI::error()`, `WP_CLI\Utils\format_items()` and friends were unknown to the analysis because WP-CLI is not a dependency. Added `php-stubs/wp-cli-stubs` as a dev dependency — the companion package to the `szepeviktor/phpstan-wordpress` extension already in use — and registered it in `scanFiles`. Production code is untouched; `build.sh` installs with `--no-dev`, and the tracked `vendor/composer/autoload_*.php` files are byte-identical after the composer run.

**`Unsafe usage of new static()` (20 errors, `includes/Support/Collection.php`)**
Annotated the class with `@phpstan-consistent-constructor` instead of sealing the constructor with `final`. Nothing subclasses `Collection`, so this is documentation-only with no runtime change.

**Non-covariant return types (6 errors, `includes/Support/Collection.php`)**
These were real PHP 8.1+ runtime deprecations, not just analysis noise — merely using a `Collection` emitted seven `Deprecated: Return type of ... should either be compatible with ...` notices. Declared the return types the plugin's PHP 7.4 floor allows (`jsonSerialize(): array`, `getIterator(): ArrayIterator`, `count(): int`, `offsetExists(): bool`, `offsetSet()/offsetUnset(): void`) and used `#[\ReturnTypeWillChange]` only on `offsetGet()`, whose tentative type is `mixed` — not declarable before PHP 8.0.

### Also

`phpstan.neon` now pins the analysis to `phpVersion: {min: 70400, max: 80400}`, matching `Requires PHP: 7.4` in readme.txt, so version-incompatible syntax is caught in the run rather than by a user.

### Verification

- `vendor/bin/phpstan analyse --memory-limit=1G` → `[OK] No errors` (across the full 7.4–8.4 range).
- `bash tests/bin/run-all.sh` → all 15 groups pass (33/33 AJAX smoke, 62/62 permissions, 84/84 integration).
- Exercised `Collection` directly — ArrayAccess set/get/unset, `foreach`, `json_encode`, `count()`, `map()`/`make()` through `new static`, closure defaults via `get()` — behaviour unchanged and the seven deprecation notices are gone.