### PR TITLE
Add Amazon SES Hyderabad region

### DIFF
--- a/app/Services/Mailer/Providers/config.php
+++ b/app/Services/Mailer/Providers/config.php
@@ -75,6 +75,7 @@ return [
                 'eu-north-1'     => __('Europe (Stockholm)', 'fluent-smtp'),
                 'eusc-de-east-1' => __('EU Sovereign Cloud (Germany, Brandenburg)', 'fluent-smtp'),
                 'ap-south-1'     => __('Asia Pacific (Mumbai)', 'fluent-smtp'),
+                'ap-south-2'     => __('Asia Pacific (Hyderabad)', 'fluent-smtp'),
                 'ap-northeast-2' => __('Asia Pacific (Seoul)', 'fluent-smtp'),
                 'ap-southeast-1' => __('Asia Pacific (Singapore)', 'fluent-smtp'),
                 'ap-southeast-2' => __('Asia Pacific (Sydney)', 'fluent-smtp'),


### PR DESCRIPTION
Adds Amazon SES Asia Pacific (Hyderabad) / ap-south-2 to the region selector.

FluentSMTP already supports dynamic SES endpoints, so this makes the supported Hyderabad region selectable.